### PR TITLE
Foliumupdate

### DIFF
--- a/msticpy/nbtools/foliummap.py
+++ b/msticpy/nbtools/foliummap.py
@@ -50,7 +50,7 @@ class FoliumMap():
         """
         self.folium_map = folium.Map(
             zoom_start=zoom_start, tiles=tiles, width=width, height=height)
-        self.folium_map.add_tile_layer(name=title)
+        folium.TileLayer(name=title).add_to(self.folium_map)
 
     def add_ip_cluster(self, ip_entities: Iterable[IpAddress], **kwargs):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrs>=18.2.0
 bokeh>=1.0.2
-folium>=0.8.2
+folium>=0.9.0
 #intake==0.4.2
 ipython>=7.2.0
 ipywidgets>=7.4.2


### PR DESCRIPTION
Folium 0.9.0 deprecated the add_tile_layer method, and replaced with use of .TileLayer
https://raw.githubusercontent.com/python-visualization/folium/master/CHANGES.txt

Update folium.py to reflect this and prevent warning appearing when running folium.py