### PR TITLE
Bug/timeline

### DIFF
--- a/msticpy/nbtools/timeline.py
+++ b/msticpy/nbtools/timeline.py
@@ -295,7 +295,10 @@ def display_timeline_values(
             p_series = []
             # create default plot args
             plot_args: Dict[str, Any] = dict(
-                x=time_column, alpha=0.7, source=row_source, legend_label=str(inline_legend)
+                x=time_column,
+                alpha=0.7,
+                source=row_source,
+                legend_label=str(inline_legend),
             )
             if "vbar" in plot_kinds:
                 p_series.append(plot.vbar(top=y, width=4, color="color", **plot_args))

--- a/msticpy/nbtools/timeline.py
+++ b/msticpy/nbtools/timeline.py
@@ -295,7 +295,7 @@ def display_timeline_values(
             p_series = []
             # create default plot args
             plot_args: Dict[str, Any] = dict(
-                x=time_column, alpha=0.7, source=row_source, legend_label=inline_legend
+                x=time_column, alpha=0.7, source=row_source, legend_label=str(inline_legend)
             )
             if "vbar" in plot_kinds:
                 p_series.append(plot.vbar(top=y, width=4, color="color", **plot_args))
@@ -491,7 +491,7 @@ def _display_timeline_dict(data: dict, **kwargs) -> figure:  # noqa: C901, MC000
                 alpha=0.5,
                 size=10,
                 source=series_def["source"],
-                legend_label=ser_name,
+                legend_label=str(ser_name),
             )
         else:
             p_series = plot.diamond(
@@ -710,7 +710,7 @@ def _plot_dict_series(data, plot, legend_pos):
                 alpha=0.5,
                 size=10,
                 source=series_def["source"],
-                legend_label=ser_name,
+                legend_label=str(ser_name),
             )
         else:
             p_series = plot.diamond(

--- a/msticpy/nbtools/timeline.py
+++ b/msticpy/nbtools/timeline.py
@@ -295,7 +295,7 @@ def display_timeline_values(
             p_series = []
             # create default plot args
             plot_args: Dict[str, Any] = dict(
-                x=time_column, alpha=0.7, source=row_source, legend=inline_legend
+                x=time_column, alpha=0.7, source=row_source, legend_label=inline_legend
             )
             if "vbar" in plot_kinds:
                 p_series.append(plot.vbar(top=y, width=4, color="color", **plot_args))
@@ -483,16 +483,25 @@ def _display_timeline_dict(data: dict, **kwargs) -> figure:  # noqa: C901, MC000
     # if legend_pos is "left" or "right", we add the legend to the side
     legend_items = []
     for ser_name, series_def in data.items():
-        inline_legend = ser_name if legend_pos == "inline" else None
-        p_series = plot.diamond(
-            x=series_def["time_column"],
-            y="y_index",
-            color=series_def["color"],
-            alpha=0.5,
-            size=10,
-            source=series_def["source"],
-            legend=inline_legend,
-        )
+        if legend_pos == "inline":
+            p_series = plot.diamond(
+                x=series_def["time_column"],
+                y="y_index",
+                color=series_def["color"],
+                alpha=0.5,
+                size=10,
+                source=series_def["source"],
+                legend_label=ser_name,
+            )
+        else:
+            p_series = plot.diamond(
+                x=series_def["time_column"],
+                y="y_index",
+                color=series_def["color"],
+                alpha=0.5,
+                size=10,
+                source=series_def["source"],
+            )
         if legend_pos in ["left", "right"]:
             legend_items.append((str(ser_name), [p_series]))
 
@@ -693,16 +702,25 @@ def _plot_dict_series(data, plot, legend_pos):
     # We plot groups individually so that we can create an interactive legend.
     legend_items = []
     for ser_name, series_def in data.items():
-        inline_legend = ser_name if legend_pos == "inline" else None
-        p_series = plot.diamond(
-            x=series_def["time_column"],
-            y="y_index",
-            color=series_def["color"],
-            alpha=0.5,
-            size=10,
-            source=series_def["source"],
-            legend=inline_legend,
-        )
+        if legend_pos == "inline":
+            p_series = plot.diamond(
+                x=series_def["time_column"],
+                y="y_index",
+                color=series_def["color"],
+                alpha=0.5,
+                size=10,
+                source=series_def["source"],
+                legend_label=ser_name,
+            )
+        else:
+            p_series = plot.diamond(
+                x=series_def["time_column"],
+                y="y_index",
+                color=series_def["color"],
+                alpha=0.5,
+                size=10,
+                source=series_def["source"],
+            )
         if legend_pos in ["left", "right"]:
             legend_items.append((ser_name, [p_series]))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs>=18.2.0
-bokeh>=1.0.4
+bokeh>=1.4.0
 cryptography>=2.8
 deprecated>=1.2.4
 dnspython>=1.16.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import setuptools
 
 INSTALL_REQUIRES = [
     "attrs>=18.2.0",
-    "bokeh>=1.0.2",
+    "bokeh>=1.4.0",
     "cryptography>=2.8",
     "deprecated>=1.2.4",
     "dnspython>=1.16.0",


### PR DESCRIPTION
Bokeh 1.4.0 changes how legends are defined:
https://docs.bokeh.org/en/latest/docs/releases.html

Specifically: 
"""
The overburdened legend keyword argument to glyph methods is deprecated. It is replaced with three purpose-specific keyword arguments:

legend_label="some_label"

This will always produce a legend item with exactly the given label.

legend_field="some_colname"

This will produce a “grouped” legend, where the grouping is done by JavaScript in the browser. Python code will only see a single legend item representing the grouping.

legend_group="some_colname"

This will produce a “grouped” legend, where the grouping is done by Python code, bedore the content is rendered in the browser. Python code will see individual legend items for each group.
"""

This PR updates the timeline function to use the new legend keyword arguments.
It also addresses updates the logic in places to address some issues found when None is passed as the legend_label argument.