### PR TITLE
TI Updates

### DIFF
--- a/msticpy/_version.py
+++ b/msticpy/_version.py
@@ -1,2 +1,2 @@
 """Version file."""
-VERSION = "0.3.3"
+VERSION = "0.3.4"

--- a/msticpy/nbtools/entityschema.py
+++ b/msticpy/nbtools/entityschema.py
@@ -72,6 +72,9 @@ class Entity(ABC):
             self.__dict__.update(kwargs)
 
         self.Type = type(self).__name__.lower()
+        # If we have an unknown entity see if we a type passed in
+        if self.Type == "unknownentity" and "Type" in kwargs:
+            self.Type = kwargs["Type"]
         self._entity_schema["Type"] = None
 
     def _extract_src_entity(self, src_entity: Mapping[str, Any]):

--- a/msticpy/nbtools/foliummap.py
+++ b/msticpy/nbtools/foliummap.py
@@ -89,7 +89,7 @@ class FoliumMap:
         Parameters
         ----------
         ip_entities : Iterable[IpAddress]
-            a iterable of IpAddress Entities
+            a iterable of IpAddress Entities 
 
         Other Parameters
         ----------------

--- a/msticpy/nbtools/foliummap.py
+++ b/msticpy/nbtools/foliummap.py
@@ -89,7 +89,7 @@ class FoliumMap:
         Parameters
         ----------
         ip_entities : Iterable[IpAddress]
-            a iterable of IpAddress Entities 
+            a iterable of IpAddress Entities
 
         Other Parameters
         ----------------

--- a/msticpy/nbtools/nbwidgets.py
+++ b/msticpy/nbtools/nbwidgets.py
@@ -424,6 +424,7 @@ class AlertSelector(QueryParamProvider):
                 "AlertName",
                 "CompromisedEntity",
                 "SystemAlertId",
+                "TI Risk",
             ]
         items = alerts[columns]
         items = items.sort_values("StartTimeUtc", ascending=True)
@@ -463,11 +464,19 @@ class AlertSelector(QueryParamProvider):
     @staticmethod
     def _alert_summary(alert_row):
         """Return summarized string of alert properties."""
-        return (
-            f"{alert_row.StartTimeUtc}  {alert_row.AlertName} "
-            + f"({alert_row.CompromisedEntity}) "
-            + f"[id:{alert_row.SystemAlertId}]"
-        )
+        if "TI Risk" in alert_row:
+            return (
+                f"{alert_row.StartTimeUtc} - {alert_row.AlertName}"
+                + f" - ({alert_row.CompromisedEntity}) "
+                + f" - [id:{alert_row.SystemAlertId}]"
+                + f" - TI Risk: {alert_row['TI Risk']}"
+            )
+        else:
+            return (
+                f"{alert_row.StartTimeUtc} - {alert_row.AlertName}"
+                + f" - ({alert_row.CompromisedEntity}) "
+                + f" - [id:{alert_row.SystemAlertId}]"
+            )
 
     def _update_options(self, change):
         """Filter the alert list by substring."""

--- a/msticpy/nbtools/nbwidgets.py
+++ b/msticpy/nbtools/nbwidgets.py
@@ -424,8 +424,8 @@ class AlertSelector(QueryParamProvider):
                 "AlertName",
                 "CompromisedEntity",
                 "SystemAlertId",
-                "TI Risk",
             ]
+
         items = alerts[columns]
         items = items.sort_values("StartTimeUtc", ascending=True)
         self._select_items = items.apply(self._alert_summary, axis=1).values.tolist()

--- a/msticpy/nbtools/security_alert.py
+++ b/msticpy/nbtools/security_alert.py
@@ -131,13 +131,23 @@ class SecurityAlert(SecurityBase):
 
     def _extract_entities(self, src_row):
         input_entities = []
+
+        if isinstance(src_row.ExtendedProperties, str):
+            try:
+                ext_props = json.loads(src_row["ExtendedProperties"])
+                for ent, val in ext_props.items():
+                    if ent in ["IpAddress", "Username"]:
+                        input_entities.append({"Entity": val, "Type": ent})
+            except json.JSONDecodeError:
+                pass
+
         if isinstance(src_row.Entities, str):
             try:
-                input_entities = json.loads(src_row["Entities"])
+                input_entities += json.loads(src_row["Entities"])
             except json.JSONDecodeError:
                 pass
         elif isinstance(src_row.Entities, list):
-            input_entities = src_row.Entities
+            input_entities += src_row.Entities
 
         for ent in input_entities:
             try:

--- a/msticpy/nbtools/security_base.py
+++ b/msticpy/nbtools/security_base.py
@@ -407,6 +407,38 @@ class SecurityBase(QueryParamProvider):
         """
         return [p for p in self.entities if p["Type"] == entity_type]
 
+    def get_all_entities(self) -> pd.DataFrame:
+        """
+        Return a DataFrame of the Alert or Event entities.
+
+        Returns
+        -------
+        DataFrame
+            Pandas DataFrame of the Alert or Event entities.
+
+        """
+        entity = []
+        ent_type = []
+        for item in self.entities:
+            if "Address" in item:
+                entity.append(item["Address"])
+                ent_type.append(item["Type"])
+            elif "Url" in item:
+                entity.append(item["Url"])
+                ent_type.append(item["Type"])
+            elif "HostName" in item:
+                entity.append(item["HostName"])
+                ent_type.append(item["Type"])
+            elif "Entity" in item:
+                entity.append(item["Entity"])
+                ent_type.append(item["Type"])
+            elif item["Type"] == "account":
+                entity.append(item["Name"])
+                ent_type.append(item["Type"])
+
+        entities = pd.DataFrame({"Entity": entity, "Type": ent_type})
+        return entities
+
     def to_html(self, show_entities: bool = False) -> str:
         """Return the item as HTML string."""
         html_doc = pd.DataFrame(self._source_data).to_html()

--- a/msticpy/sectools/tilookup.py
+++ b/msticpy/sectools/tilookup.py
@@ -112,6 +112,22 @@ class TILookup:
         return prim + sec
 
     @property
+    def configured_providers(self) -> List[str]:
+        """
+        Return a list of avaliable providers that have configuration details present.
+
+        Returns
+        -------
+        List[str]
+            List of TI Provider classes.
+
+        """
+        prim_conf = list(self._providers.keys())
+        sec_conf = list(self._secondary_providers.keys())
+
+        return prim_conf + sec_conf
+
+    @property
     def available_providers(self) -> List[str]:
         """
         Return a list of builtin providers.

--- a/msticpy/sectools/tilookup.py
+++ b/msticpy/sectools/tilookup.py
@@ -135,7 +135,9 @@ class TILookup:
                 providers.append(provider_class.__name__)
         return providers
 
-    def list_available_providers(self, show_query_types=False):  # type: ignore
+    def list_available_providers(
+        self, show_query_types=False, return_list: bool = False
+    ):  # type: ignore
         """
         Print a list of builtin providers with optional usage.
 
@@ -145,11 +147,16 @@ class TILookup:
             Show query types supported by providers, by default False
 
         """
+        providers = []
         for provider_name in self.available_providers:
             provider_class = getattr(tiproviders, provider_name, None)
-            print(provider_name)
+            if return_list is False:
+                print(provider_name)
+            providers.append(provider_name)
             if show_query_types:
                 provider_class.usage()
+        if return_list is True:
+            return providers
 
     def provider_usage(self):
         """Print usage of loaded providers."""

--- a/msticpy/sectools/tiproviders/ti_provider_base.py
+++ b/msticpy/sectools/tiproviders/ti_provider_base.py
@@ -70,13 +70,13 @@ class LookupResult:
     def _check_severity(self, attribute, value):
         del attribute
         if isinstance(value, TISeverity):
-            self.severity = value.value
+            self.severity = value.name
         elif isinstance(value, str) and value.lower() in TISeverity.__members__:
-            self.severity = TISeverity[value.lower()].value
+            self.severity = TISeverity[value.lower()].name
         elif isinstance(value, int) and 0 <= value <= 2:
-            self.severity = TISeverity(value).value
+            self.severity = TISeverity(value).name
         else:
-            self.severity = TISeverity.information.value
+            self.severity = TISeverity.information.name
 
     @property
     def summary(self):

--- a/msticpy/sectools/tiproviders/virustotal.py
+++ b/msticpy/sectools/tiproviders/virustotal.py
@@ -83,6 +83,7 @@ class VirusTotal(HttpProvider):
             Object with match details
 
         """
+
         if self._failed_response(response) or not isinstance(response.raw_result, dict):
             return False, TISeverity.information, "Not found."
 
@@ -145,13 +146,16 @@ class VirusTotal(HttpProvider):
                     ]
                 )
                 result_dict["positives"] += positives
-
-        if result_dict["positives"] > 1:
-            severity = TISeverity.high
-        elif result_dict["positives"] > 0:
-            severity = TISeverity.warning
+        
+        if "positives" in result_dict:
+            if result_dict["positives"] > 1:
+                severity = TISeverity.high
+            elif result_dict["positives"] > 0:
+                severity = TISeverity.warning
+            else:
+                severity = TISeverity.information
         else:
-            severity = TISeverity.information
+            severity = None
 
         return True, severity, result_dict
 

--- a/msticpy/sectools/tiproviders/virustotal.py
+++ b/msticpy/sectools/tiproviders/virustotal.py
@@ -146,7 +146,7 @@ class VirusTotal(HttpProvider):
                     ]
                 )
                 result_dict["positives"] += positives
-        
+
         if "positives" in result_dict:
             if result_dict["positives"] > 1:
                 severity = TISeverity.high

--- a/msticpy/sectools/tiproviders/virustotal.py
+++ b/msticpy/sectools/tiproviders/virustotal.py
@@ -12,6 +12,7 @@ processing performance may be limited to a specific number of
 requests per minute for the account type that you have.
 
 """
+import datetime as dt
 from typing import Any, Tuple
 
 from .ti_provider_base import LookupResult, TISeverity
@@ -99,26 +100,59 @@ class VirusTotal(HttpProvider):
             result_dict["resource"] = response.raw_result.get("resource", None)
             result_dict["permalink"] = response.raw_result.get("permalink", None)
             result_dict["positives"] = response.raw_result.get("positives", 0)
-        if "detected_urls" in response.raw_result:
-            result_dict["detected_urls"] = [
-                item["url"]
-                for item in response.raw_result["detected_urls"]
-                if "url" in item
-            ]
-            # positives are listed per detected_url so we need to
-            # pull those our and sum them.
-            positives = sum(
-                [
-                    item["positives"]
-                    for item in response.raw_result["detected_urls"]
-                    if "positives" in item
-                ]
-            )
-            result_dict["positives"] = positives
 
-        severity = (
-            TISeverity.high if result_dict["positives"] > 0 else TISeverity.information
-        )
+        else:
+            if "detected_urls" in response.raw_result:
+                time_scope = dt.datetime.now() - dt.timedelta(days=30)
+                result_dict["detected_urls"] = [
+                    item["url"]
+                    for item in response.raw_result["detected_urls"]
+                    if "url" in item
+                    and dt.datetime.strptime(item["scan_date"], "%Y-%m-%d %H:%M:%S")
+                    > time_scope
+                ]
+                # positives are listed per detected_url so we need to
+                # pull those our and sum them.
+                positives = sum(
+                    [
+                        item["positives"]
+                        for item in response.raw_result["detected_urls"]
+                        if "positives" in item
+                        and dt.datetime.strptime(item["scan_date"], "%Y-%m-%d %H:%M:%S")
+                        > time_scope
+                    ]
+                )
+                result_dict["positives"] = positives
+
+            if "detected_downloaded_samples" in response.raw_result:
+                time_scope = dt.datetime.now() - dt.timedelta(days=30)
+                result_dict["detected_downloaded_samples"] = [
+                    item["sha256"]
+                    for item in response.raw_result["detected_downloaded_samples"]
+                    if "sha256" in item
+                    and dt.datetime.strptime(item["date"], "%Y-%m-%d %H:%M:%S")
+                    > time_scope
+                ]
+                # positives are listed per detected_url so we need to
+                # pull those our and sum them.
+                positives = sum(
+                    [
+                        item["positives"]
+                        for item in response.raw_result["detected_downloaded_samples"]
+                        if "positives" in item
+                        and dt.datetime.strptime(item["date"], "%Y-%m-%d %H:%M:%S")
+                        > time_scope
+                    ]
+                )
+                result_dict["positives"] += positives
+
+        if result_dict["positives"] > 1:
+            severity = TISeverity.high
+        elif result_dict["positives"] > 0:
+            severity = TISeverity.warning
+        else:
+            severity = TISeverity.information
+
         return True, severity, result_dict
 
     # pylint: enable=duplicate-code

--- a/tests/test_tiproviders.py
+++ b/tests/test_tiproviders.py
@@ -347,7 +347,7 @@ class TestTIProviders(unittest.TestCase):
             for prov, lu_result in result[1]:
                 self.assertIsNotNone(lu_result.ioc)
                 self.assertIsNotNone(lu_result.ioc_type)
-                if lu_result.severity > 0:
+                if lu_result.severity in ["warning", "high"]:
                     self.assertTrue(
                         "rank" in lu_result.details
                         and lu_result.details["rank"] is None
@@ -378,9 +378,8 @@ class TestTIProviders(unittest.TestCase):
         n_requests = 250
         gen_doms = {self._generate_rand_domain(): "dns" for i in range(n_requests)}
         results_df = ti_lookup.lookup_iocs(data=gen_doms, providers=["OPR"])
-
         self.assertEqual(n_requests, len(results_df))
-        self.assertGreater(len(results_df[results_df["Severity"] > 0]), n_requests / 3)
+        self.assertGreater(len(results_df[results_df["Severity"].isin(["warning", "high"]) > 0]), n_requests / 3)
         self.assertEqual(n_requests, len(results_df[results_df["Result"] == True]))
 
     def _generate_rand_domain(self):
@@ -420,7 +419,7 @@ class TestTIProviders(unittest.TestCase):
             lu_result = result[1][0][1]
             self.assertTrue(lu_result.result)
             self.assertTrue(bool(lu_result.reference))
-            if lu_result.severity > 0:
+            if lu_result.severity in ["warning", "high"]:
                 self.assertTrue(bool(lu_result.details))
                 self.assertTrue(bool(lu_result.raw_result))
                 pos_results.append(lu_result)
@@ -433,8 +432,8 @@ class TestTIProviders(unittest.TestCase):
         all_ips = tor_nodes + other_ips
         tor_results_df = ti_lookup.lookup_iocs(data=all_ips, providers=["Tor"])
         self.assertEqual(len(all_ips), len(tor_results_df))
-        self.assertEqual(len(tor_results_df[tor_results_df["Severity"] > 0]), 4)
-        self.assertEqual(len(tor_results_df[tor_results_df["Severity"] == 0]), 5)
+        self.assertEqual(len(tor_results_df[tor_results_df["Severity"].isin(["warning", "high"])]), 4)
+        self.assertEqual(len(tor_results_df[tor_results_df["Severity"] == 'information']), 5)
 
     def test_check_ioc_type(self):
         provider = self.ti_lookup.loaded_providers["OTX"]


### PR DESCRIPTION
This PR mostly includes changes to the TI Providers (and associated elements) in order to facilitate more accurate and readable severity scoring. There are also changes to allow for easier use of TiProvider elements within Notebooks.

In addition there are several changes to the alert entities to make them more accurate and usable in Notebooks. These features are used in the Alert Triage Notebook.

Change Details:
- If an alert entity of unknown type we now check to see if a type was passed to the entity when it was created that can be used.
- In the AlertViewer widget, if your alert table has a column called "TI Risk" this will appear in the details of alerts in the selection widget.
- Alert entities now include ipaddress or username that are listed in ExtendedProperties.
- You can call securityalert.get_all_entities() to get details of all alert entities in a standardized DataFrame.
- tilookup.configured_providers returns as list of all TI providers loaded, and for which configuration details are present in the configuration file.
- tilookup.list_available_providers() can now return a list of providers (rather than just printing them) with the return_list flag set to True
- Ti lookup severity now returns a string representation rather than an integer to provider an easier to understand summary of findings that does not conflict with TI provider UI representations. (This is specifically due to VT feedback from Tim B).
- VT domain lookups now only calculate severity based on detections made in the last 30 days (previously this was based on any previous detection regardless of age).
- Tests updated to reflect changes made to TI providers.