### PR TITLE
make titles consistent on the widgets page

### DIFF
--- a/docs/source/visualization/NotebookWidgets.rst
+++ b/docs/source/visualization/NotebookWidgets.rst
@@ -24,6 +24,7 @@ picking items from a list or tracking progress of a long-running event.
 
 
 QueryTime
+---------
 
 See :py:class:`QueryTime<msticpy.nbtools.nbwidgets.QueryTime>`
 
@@ -196,6 +197,7 @@ dictionary of items.
 
 
 GetEnvironmentKey
+-----------------
 
 See :py:class:`GetEnvironmentKey<msticpy.nbtools.nbwidgets.GetEnvironmentKey>`
 


### PR DESCRIPTION
This is a little bit neater and fixes the navigation sidebar on readthedocs
https://msticpy.readthedocs.io/en/latest/visualization/NotebookWidgets.html