### PR TITLE
Remove typing - Redundant Requirement

### DIFF
--- a/conda/conda-reqs.txt
+++ b/conda/conda-reqs.txt
@@ -28,5 +28,4 @@ seaborn>=0.9.0
 setuptools>=40.6.3
 statsmodels
 tqdm>=4.36.1
-typing>=3.6.6
 urllib3>=1.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,5 +42,4 @@ splunk-sdk>=1.6.0
 statsmodels>=0.11.1
 tldextract>=2.2.2
 tqdm>=4.36.1
-typing>=3.6.6
 urllib3>=1.23

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ INSTALL_REQUIRES = [
     "statsmodels>=0.11.1",
     "tldextract>=2.2.2",
     "tqdm>=4.36.1",
-    "typing>=3.6.6",
     "urllib3>=1.23",
 ]
 


### PR DESCRIPTION
> NOTE: in Python 3.5 and later, the typing module lives in the stdlib, and installing this package has NO EFFECT, because stdlib takes higher precedence than the installation directory.

As msticpy requires Python 3.6 and above, this is now a redundant requirement.

Refer: https://pypi.org/project/typing/