### PR TITLE
Updated vt-py to 0.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ statsmodels>=0.11.1
 tldextract>=2.2.2
 tqdm>=4.36.1
 urllib3>=1.23
+vt-py>=0.6.1


### PR DESCRIPTION
This PR updates `vt-py` repository to version `0.6.1`, where issue with `pytest` is fixed.