### PR TITLE
Fix broken link to MPSettingsEditor.ipynb

### DIFF
--- a/docs/source/getting_started/SettingsEditor.rst
+++ b/docs/source/getting_started/SettingsEditor.rst
@@ -9,7 +9,7 @@ from scratch.
 
 There is also a notebook that follows this flow. You can download
 and use this to configure your settings -
-`MPSettingsEditor <https://github.com/microsoft/msticpy/blob/master/docs/notebooks/MPSettings.ipynb>`__
+`MPSettingsEditor <https://github.com/microsoft/msticpy/blob/master/docs/notebooks/MPSettingsEditor.ipynb>`__
 
 You should also read the companion document
 :doc:`*MSTICPy* Package Configuration <msticpyconfig>`, which has


### PR DESCRIPTION
Fix broken link to MPSettingsEditor.ipynb in SettingsEditor.rst doc. 