### PR TITLE
Ianhelle/mp pivot suppress exceptions 2021 06 28

### DIFF
--- a/msticpy/_version.py
+++ b/msticpy/_version.py
@@ -1,2 +1,2 @@
 """Version file."""
-VERSION = "1.2.2"
+VERSION = "1.2.3"

--- a/msticpy/common/exceptions.py
+++ b/msticpy/common/exceptions.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 """Miscellaneous helper methods for Jupyter Notebooks."""
+import contextlib
 from typing import List, Tuple, Union
 
 from IPython.display import display
@@ -44,6 +45,8 @@ class MsticpyResourceException(MsticpyException):
 # "Exception" suffix
 class MsticpyUserError(MsticpyException):
     """Msticpy User exception displaying friendly message."""
+
+    _display_exceptions = True
 
     DEF_HELP_URI = ("msticpy documentation", "https://msticpy.readthedocs.org")
 
@@ -115,12 +118,22 @@ class MsticpyUserError(MsticpyException):
         ex_args = [title, *args, help_uri, *help_args]
         super().__init__(*ex_args)
 
+    @classmethod
+    @contextlib.contextmanager
+    def no_display_exceptions(cls):
+        """Context manager to block exception display to IPython/stdout."""
+        cls._display_exceptions = False
+        yield
+        cls._display_exceptions = True
+
     @property
     def help_uri(self) -> Union[Tuple[str, str], str]:
         """Get the default help URI."""
         return self.DEF_HELP_URI
 
     def _display_exception(self):
+        if not self._display_exceptions:
+            return
         if is_ipython():
             display(self)
         else:

--- a/msticpy/datamodel/pivot_register_reader.py
+++ b/msticpy/datamodel/pivot_register_reader.py
@@ -11,7 +11,11 @@ import warnings
 import yaml
 
 from .._version import VERSION
-from ..common.exceptions import MsticpyUserConfigError, MsticpyException
+from ..common.exceptions import (
+    MsticpyUserConfigError,
+    MsticpyException,
+    MsticpyUserError,
+)
 from ..data.query_container import QueryContainer
 from . import entities
 from .pivot_register import PivotRegistration, create_pivot_func
@@ -71,12 +75,14 @@ def register_pivots(  # noqa: MC0001
             # if we need to get this from a class/object we need
             # to find or create one.
             func = None
-            try:
-                func = _get_func_from_class(src_module, namespace, piv_reg)
-            except MsticpyException:
-                print(
-                    f"Unable to add pivot functions from class '{piv_reg.src_class}'. Skipping"
-                )
+            # Suppress Msticpy exception display when instantiating classes.
+            with MsticpyUserError.no_display_exceptions():
+                try:
+                    func = _get_func_from_class(src_module, namespace, piv_reg)
+                except MsticpyException:
+                    print(
+                        f"Unable to add pivot functions from class '{piv_reg.src_class}'. Skipping"
+                    )
             if not func:
                 continue
         else:

--- a/msticpy/sectools/geoip.py
+++ b/msticpy/sectools/geoip.py
@@ -219,10 +219,7 @@ Alternatively, you can pass this to the IPStackLookup class when creating it:
         super().__init__()
 
         self.settings = _get_geoip_provider_settings("IPStack")
-        if api_key:
-            self._api_key = api_key
-        else:
-            self._api_key = self.settings.args.get("AuthKey")  # type: ignore
+        self._api_key = api_key or self.settings.args.get("AuthKey")
         if not self._api_key:
             raise MsticpyUserConfigError(
                 self._NO_API_KEY_MSSG,
@@ -360,18 +357,15 @@ Alternatively, you can pass this to the IPStackLookup class when creating it:
                 response = session.get(submit_url)
                 if response.status_code == 200:
                     ip_loc_results.append((response.json(), response.status_code))
+                elif response:
+                    try:
+                        ip_loc_results.append((response.json(), response.status_code))
+                        continue
+                    except JSONDecodeError:
+                        ip_loc_results.append((None, response.status_code))
                 else:
-                    if response:
-                        try:
-                            ip_loc_results.append(
-                                (response.json(), response.status_code)
-                            )
-                            continue
-                        except JSONDecodeError:
-                            ip_loc_results.append((None, response.status_code))
-                    else:
-                        print("Unknown response from IPStack request.")
-                        ip_loc_results.append((None, -1))
+                    print("Unknown response from IPStack request.")
+                    ip_loc_results.append((None, -1))
         return ip_loc_results
 
 


### PR DESCRIPTION
Added mechanism to stop standard display of msticpy user
exceptions. Context manager in MsticpyUserError:
``` python
from msticpy.common.exceptions import MsticpyUserError
with MsticpyUserError.no_display_exceptions():
   # do stuff that may cause exceptions to be displayed.
```
Note this doesn't suppress the exception, just stops exception being output to a notebook.
This is needed because MsticpyUserError and subclasses will display to IPython or stdout when
created, even if the exception is subsequently caught.