### PR TITLE
fix img src paths for broken preview images in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It also includes some time-saving notebook tools such as widgets to
 set query time boundaries, select and display items from lists, and
 configure the notebook environment.
 
-<img src="https://github.com/microsoft/msticpy/blob/master/docs/source/visualization/_static/Timeline-08.png"
+<img src="./docs/source/visualization/_static/Timeline-08.png"
 alt="Timeline" title="Msticpy Timeline Control" height="300" />
 
 The **msticpy** package was initially developed to support
@@ -114,7 +114,7 @@ using either:
 - GeoLiteLookup - Maxmind Geolite (see <https://www.maxmind.com>)
 - IPStackLookup  - IPStack (see <https://ipstack.com>)
 
-<img src="https://github.com/microsoft/msticpy/blob/master/docs/source/visualization/_static/FoliumMap-01.png"
+<img src="./docs/source/visualization/_static/FoliumMap-01.png"
   alt="Folium map"
   title="Plotting Geo IP Location" height="200" />
 
@@ -156,7 +156,7 @@ events over hours of the day, days of the week, etc.). Using both analysis and
 visualization highlights unusual traffic flows or event activity for any data
 set.
 
-<img src="https://github.com/microsoft/msticpy/blob/master/docs/source/visualization/_static/TimeSeriesAnomalieswithRangeTool.png"
+<img src="./docs/source/visualization/_static/TimeSeriesAnomalieswithRangeTool.png"
 alt="Time Series anomalies" title="Time Series anomalies" height="300" />
 
 [Time Series](https://msticpy.readthedocs.io/en/latest/visualization/TimeSeriesAnomalies.html)
@@ -170,7 +170,7 @@ Display any log events on an interactive timeline. Using the
 you to visualize one or more event streams, interactively zoom into specific time
 slots and view event details for plotted events.
 
-<img src="https://github.com/microsoft/msticpy/blob/master/docs/source/visualization/_static/TimeLine-01.png"
+<img src="./docs/source/visualization/_static/TimeLine-01.png"
 alt="Timeline" title="Msticpy Timeline Control" height="300" />
 
 [Timeline](https://msticpy.readthedocs.io/en/latest/visualization/EventTimeline.html)
@@ -187,7 +187,7 @@ The process tree functionality has two main components:
 
 There are a set of utility functions to extract individual and partial trees from the processed data set.
 
-<img src="https://github.com/microsoft/msticpy/blob/master/docs/source/visualization/_static/process_tree3.png"
+<img src="./docs/source/visualization/_static/process_tree3.png"
 alt="Process Tree"
 title="Interactive Process Tree" height="400" />
 
@@ -235,7 +235,7 @@ This module is intended to be used to summarize large numbers of
 events into clusters of different patterns. High volume repeating
 events can often make it difficult to see unique and interesting items.
 
-<img src="https://github.com/microsoft/msticpy/blob/master/docs/source/data_analysis/_static/EventClustering_2a.png"
+<img src="./docs/source/data_analysis/_static/EventClustering_2a.png"
   alt="Clustering"
   title="Clustering based on command-line variability" height="400" />
 
@@ -274,11 +274,11 @@ These are built from the [Jupyter ipywidgets](https://ipywidgets.readthedocs.io/
 and group common functionality useful in InfoSec tasks such as list pickers,
 query time boundary settings and event display into an easy-to-use format.
 
-<img src="https://github.com/microsoft/msticpy/blob/master/docs/source/visualization/_static/Widgets1.png"
+<img src="./docs/source/visualization/_static/Widgets1.png"
   alt="Time span Widget"
   title="Query time setter" height="100" />
 
-<img src="https://github.com/microsoft/msticpy/blob/master/docs/source/visualization/_static/Widgets4.png"
+<img src="./docs/source/visualization/_static/Widgets4.png"
   alt="Alert browser"
   title="Alert browser" height="300" />
 


### PR DESCRIPTION
 - fix img src paths to local to preview images correctly.