### PR TITLE
Implemented lazy loading of config editor tabs to try to improve performance on AML

### DIFF
--- a/msticpy/_version.py
+++ b/msticpy/_version.py
@@ -1,2 +1,2 @@
 """Version file."""
-VERSION = "1.4.4"
+VERSION = "1.4.5"

--- a/msticpy/config/comp_edit.py
+++ b/msticpy/config/comp_edit.py
@@ -4,9 +4,9 @@
 # license information.
 # --------------------------------------------------------------------------
 """Component Edit base and mixin classes."""
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from time import sleep
-from typing import Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import ipywidgets as widgets
 from IPython.display import display
@@ -128,46 +128,6 @@ class CompEditHelp:
         return self.accdn_help
 
 
-class CompEditTabs:
-    """Tab class."""
-
-    def __init__(self, tabs: Optional[Dict[str, widgets.Widget]] = None):
-        """Initialize the class."""
-        self.tab = widgets.Tab()
-        self.layout = self.tab
-        self.tab_controls = tabs or {}
-        if self.tab_controls:
-            for tab_name, tab_ctrl in self.tab_controls.items():
-                self.add_tab(tab_name, tab_ctrl)
-
-    def add_tab(self, tab_name: str, control: widgets.Widget):
-        """Add a tab with name `tab_name` and content `control`."""
-        self.tab_controls[tab_name] = control
-        tab_children = list(self.tab.children)
-        new_idx = len(tab_children)
-        tab_children.append(control.layout)
-        self.tab.children = tab_children
-        self.tab.set_title(new_idx, tab_name)
-
-    def set_tab(self, tab_name: Optional[str], index: int = 0):
-        """Programatically set the tab by name or index."""
-        if tab_name:
-            tab_index = [
-                idx
-                for idx, tabname in enumerate(self.tab_controls)
-                if tab_name.casefold() == tabname.casefold()
-            ]
-            if tab_index:
-                self.tab.selected_index = tab_index[0]
-            return
-        self.tab.selected_index = index
-
-    @property
-    def tab_names(self):
-        """Return a list of current tabs."""
-        return list(enumerate(self.tab_controls.keys()))
-
-
 class CompEditFrame(CompEditDisplayMixin, CompEditUtilsMixin, CompEditStatusMixin):
     """Edit frame class for components."""
 
@@ -265,10 +225,116 @@ class CEItemsBase(CompEditItems, ABC):
 class SettingsControl(ABC):
     """Abstract base class for settings controls."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def value(self) -> Union[str, Dict[str, Optional[str]]]:
         """Return the current value of the control."""
 
     @value.setter
     def value(self, value: Union[str, Dict[str, Optional[str]]]):
         """Set value of controls from dict."""
+
+
+CETabControlDef = Tuple[type, Union[List[Any], Dict[str, Any]]]
+
+
+class CompEditTabs:
+    """Tab class."""
+
+    def __init__(self, tabs: Optional[Dict[str, CETabControlDef]] = None):
+        """
+        Initialize the CompEditTabs class.
+
+        Parameters
+        ----------
+        tabs : Optional[Dict[str, Tuple[type, Union[List[Any], Dict[str, Any]]]]], optional
+            Tab definitions or contents, by default None.
+            Each definition can be a Tuple of class and list of args
+            or a Tuple of class and dict of kwargs.
+
+        """
+        self.tab = widgets.Tab()
+        self.layout = self.tab
+        tabs = tabs or {}
+        self._tab_state: List[widgets.Widget] = []
+        self._tab_lazy_load: Dict[int, CETabControlDef] = {}
+        self._tab_names: List[str] = []
+        self.controls: Dict[str, Any] = {}
+        if tabs:
+            for tab_name, tab_ctrl in tabs.items():
+                if isinstance(tab_ctrl, CEItemsBase):
+                    # if this is an already-instantiated widget, just add the tab
+                    self.add_tab(tab_name, tab_ctrl)
+                    self._tab_state.append(tab_ctrl.layout)
+                elif isinstance(tab_ctrl, tuple):
+                    # if we're doing lazy loading, add a lazy-load tab
+                    self._add_lazy_tab(tab_name, tab_ctrl)
+            if self._tab_lazy_load:
+                # Make sure content is loaded for tab 0
+                self._load_tab(0)
+        self.tab.observe(self._on_select_tab, names="selected_index")
+
+    def _load_tab(self, tab_index):
+        """Load any lazily-loaded tab content."""
+        if not self._tab_lazy_load:
+            return
+        if isinstance(self._tab_state[tab_index], widgets.Label):
+            wgt_cls, args = self._tab_lazy_load[tab_index]
+            # initialize the class object with args or kwargs
+            ctrl = wgt_cls(*args) if isinstance(args, list) else wgt_cls(**args)
+            # set this control as the current tab state
+            self._tab_state[tab_index] = ctrl.layout
+            # update the controls dict
+            self.controls[self._tab_names[tab_index]] = ctrl
+            # update the tab control children with the new state
+            self.tab.children = self._tab_state
+
+    def _on_select_tab(self, change):
+        """Handle tab select index events."""
+        tab_index = change.get("new")
+        self._load_tab(tab_index)
+
+    def add_tab(self, tab_name: str, control: CEItemsBase):
+        """Add a tab with name `tab_name` and content `control`."""
+        self._tab_names.append(tab_name)
+        new_idx = len(self._tab_state)
+        self._tab_state.append(control.layout)
+        self.tab.children = self._tab_state
+        self.tab.set_title(new_idx, tab_name)
+        self.controls[tab_name] = control
+
+    def _add_lazy_tab(self, tab_name: str, control_def: CETabControlDef):
+        """Add a lazily-loaded tab with name `tab_name` and definition `control_def`."""
+        self._tab_names.append(tab_name)
+        new_idx = len(self._tab_state)
+        # add dummy control to tab state and control def to lazy tab dict
+        dummy_ctrl = widgets.Label(value="")
+        self._tab_state.append(dummy_ctrl)
+        self._tab_lazy_load[new_idx] = control_def
+        self.controls[tab_name] = dummy_ctrl
+        # Refresh tab control children and set title
+        self.tab.children = self._tab_state
+        self.tab.set_title(new_idx, tab_name)
+
+    def set_tab(self, tab_name: Optional[str], index: int = 0):
+        """Programatically set the tab by name or index."""
+        if tab_name:
+            tab_index = [
+                idx
+                for idx, tabname in enumerate(self._tab_names)
+                if tab_name.casefold() == tabname.casefold()
+            ]
+            if tab_index:
+                self.tab.selected_index = tab_index[0]
+            return
+        self.tab.selected_index = index
+
+    @property
+    def tab_names(self) -> List[str]:
+        """Return a list of current tabs."""
+        return self._tab_names
+
+    @property
+    def tab_controls(self) -> Dict[str, Any]:
+        """Return a list of current tab names and controls."""
+        return self.controls

--- a/msticpy/config/comp_edit.py
+++ b/msticpy/config/comp_edit.py
@@ -308,7 +308,7 @@ class CompEditTabs:
         self._tab_names.append(tab_name)
         new_idx = len(self._tab_state)
         # add dummy control to tab state and control def to lazy tab dict
-        dummy_ctrl = widgets.Label(value="")
+        dummy_ctrl = widgets.Label(value="loading...")
         self._tab_state.append(dummy_ctrl)
         self._tab_lazy_load[new_idx] = control_def
         self.controls[tab_name] = dummy_ctrl

--- a/msticpy/config/mp_config_edit.py
+++ b/msticpy/config/mp_config_edit.py
@@ -16,7 +16,7 @@ from .ce_azure import CEAzure
 from .ce_other_providers import CEOtherProviders
 from .ce_ti_providers import CETIProviders
 from .ce_user_defaults import CEAutoLoadComps, CEAutoLoadQProvs
-from .comp_edit import CompEditDisplayMixin, CompEditTabs
+from .comp_edit import CompEditDisplayMixin, CompEditTabs, CETabControlDef
 from .mp_config_file import MpConfigFile
 from .mp_config_control import MpConfigControls, get_mpconfig_definitions
 
@@ -26,6 +26,17 @@ __author__ = "Ian Hellen"
 
 class MpConfigEdit(CompEditDisplayMixin):
     """Msticpy Configuration helper class."""
+
+    _TAB_DEFINITIONS = {
+        "AzureSentinel": CEAzureSentinel,
+        "TI Providers": CETIProviders,
+        "Data Providers": CEDataProviders,
+        "GeoIP Providers": CEOtherProviders,
+        "Key Vault": CEKeyVault,
+        "Azure": CEAzure,
+        "Autoload QueryProvs": CEAutoLoadQProvs,
+        "Autoload Components": CEAutoLoadComps,
+    }
 
     def __init__(
         self,
@@ -70,11 +81,12 @@ class MpConfigEdit(CompEditDisplayMixin):
             self.mp_conf_file.load_default()
         self.tool_buttons: Dict[str, widgets.Widget] = {}
 
+        # Get the settings definitions and Config controls object
         mp_def_dict = get_mpconfig_definitions()
         self.mp_controls = MpConfigControls(mp_def_dict, self.mp_conf_file.settings)
-        self.tab_ctrl = CompEditTabs()
-        self.controls: Dict[str, Any] = {}
-        self._create_data_tabs(self.mp_controls)
+        # Set up the tabs
+        self.tab_ctrl = CompEditTabs(self._get_tab_definitions())
+        # self._create_data_tabs(self.mp_controls)
 
         self.txt_current_file = widgets.Text(
             description="Conf File",
@@ -99,6 +111,11 @@ class MpConfigEdit(CompEditDisplayMixin):
     def tab_names(self):
         """Return a list of current tabs."""
         return self.tab_ctrl.tab_names
+
+    @property
+    def controls(self):
+        """Return a list of current tab names and controls."""
+        return self.tab_ctrl.tab_controls
 
     def set_tab(self, tab_name: Optional[str], index: int = 0):
         """Programatically set the tab by name or index."""
@@ -128,23 +145,22 @@ class MpConfigEdit(CompEditDisplayMixin):
             ]
         )
 
-    def _create_data_tabs(self, mp_controls):
-        self.controls = {
-            "AzureSentinel": CEAzureSentinel(mp_controls),
-            "TI Providers": CETIProviders(mp_controls),
-            "Data Providers": CEDataProviders(mp_controls),
-            "GeoIP Providers": CEOtherProviders(mp_controls),
-            "Key Vault": CEKeyVault(mp_controls),
-            "Azure": CEAzure(mp_controls),
-            "Autoload QueryProvs": CEAutoLoadQProvs(mp_controls),
-            "Autoload Components": CEAutoLoadComps(mp_controls),
-        }
+    def _create_data_tabs(self):
+        """Create all tab contents."""
         self.tab_ctrl.tab.children = []
-        for name, ctrl in self.controls.items():
+        for name, (ctrl_cls, args) in self._get_tab_definitions().items():
+            ctrl = ctrl_cls(*args)
             # add to tabs
             self.tab_ctrl.add_tab(name, control=ctrl)
             # Set these controls as named attributes on the object
             setattr(self, name.replace(" ", "_"), ctrl)
+
+    def _get_tab_definitions(self) -> Dict[str, CETabControlDef]:
+        """Return tab definitions and arguments."""
+        return {
+            name: (cls, [self.mp_controls])
+            for name, cls in self._TAB_DEFINITIONS.items()
+        }
 
     @property
     def current_config_file(self):

--- a/msticpy/config/mp_config_edit.py
+++ b/msticpy/config/mp_config_edit.py
@@ -7,6 +7,7 @@
 from typing import Any, Dict, Optional, Union
 
 import ipywidgets as widgets
+from IPython.display import display
 
 from .._version import VERSION
 from .ce_azure_sentinel import CEAzureSentinel
@@ -65,6 +66,8 @@ class MpConfigEdit(CompEditDisplayMixin):
             If settings is a file path, this parameter is ignored.
 
         """
+        self._lbl_loading = widgets.Label(value="Loading. Please wait.")
+        display(self._lbl_loading)
         if isinstance(settings, MpConfigFile):
             self.mp_conf_file = MpConfigFile(settings=settings.settings)
             if not self.mp_conf_file.current_file and conf_filepath:
@@ -80,13 +83,16 @@ class MpConfigEdit(CompEditDisplayMixin):
             self.mp_conf_file = MpConfigFile()
             self.mp_conf_file.load_default()
         self.tool_buttons: Dict[str, widgets.Widget] = {}
+        self._inc_loading_label()
 
         # Get the settings definitions and Config controls object
         mp_def_dict = get_mpconfig_definitions()
         self.mp_controls = MpConfigControls(mp_def_dict, self.mp_conf_file.settings)
+        self._inc_loading_label()
+
         # Set up the tabs
         self.tab_ctrl = CompEditTabs(self._get_tab_definitions())
-        # self._create_data_tabs(self.mp_controls)
+        self._inc_loading_label()
 
         self.txt_current_file = widgets.Text(
             description="Conf File",
@@ -106,6 +112,10 @@ class MpConfigEdit(CompEditDisplayMixin):
             ]
         )
         self.layout = widgets.VBox([self.tab_ctrl.layout, vbox])
+        self._lbl_loading.layout.visibility = "hidden"
+
+    def _inc_loading_label(self):
+        self._lbl_loading.value = f"{self._lbl_loading.value}."
 
     @property
     def tab_names(self):

--- a/msticpy/datamodel/entities/entity.py
+++ b/msticpy/datamodel/entities/entity.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 """Entity Entity class."""
+import json
 import pprint
 import typing
 from abc import ABC
@@ -209,7 +210,7 @@ class Entity(ABC, Node):
 
     def __str__(self) -> str:
         """Return string representation of entity."""
-        return pprint.pformat(self._to_dict(self), indent=2, width=100)
+        return pprint.pformat(self._to_dict(), indent=2, width=100)
 
     def __repr__(self) -> str:
         """Return repr of entity."""
@@ -221,13 +222,15 @@ class Entity(ABC, Node):
             params = params[:80] + "..."
         return f"{self.__class__.__name__}({params})"
 
-    def _to_dict(self, entity) -> dict:
+    def _to_dict(self) -> dict:
         """Return as simple nested dictionary."""
+        # pylint: disable=protected-access
         return {
-            prop: self._to_dict(val) if isinstance(val, Entity) else val
-            for prop, val in entity.properties.items()
+            prop: val._to_dict() if isinstance(val, Entity) else val
+            for prop, val in self.properties.items()
             if val is not None
         }
+        # pylint: enable=protected-access
 
     def _repr_html_(self) -> str:
         """
@@ -255,6 +258,12 @@ class Entity(ABC, Node):
         e_type = self.Type
         e_text = e_text.replace("\n", "<br>").replace(" ", "&nbsp;")
         return f"<h3>{e_type}</h3>{e_text}"
+
+    def toJSON(self):  # noqa: N802
+        """Return object as a JSON string."""
+        return json.dumps(
+            {name: val for name, val in self._to_dict().items() if name != "edges"}
+        )
 
     def __eq__(self, other: Any) -> bool:
         """


### PR DESCRIPTION
By default it only instantiates and loads the first tab - others are loaded on demand as tabs are clicked