### PR TITLE
Ianhelle/kusto and md365 support 2021 11 01

### DIFF
--- a/docs/notebooks/GeoIPLookups.ipynb
+++ b/docs/notebooks/GeoIPLookups.ipynb
@@ -721,16 +721,19 @@
     }
    ],
    "source": [
+    "import os\n",
     "if not iplocation.settings.args.get(\"AuthKey\") and not ips_key.value:\n",
     "    raise ValueError(\"No Authentication key in config/environment or supplied by user.\")\n",
     "if ips_key.value:\n",
     "    iplocation = IPStackLookup(api_key=ips_key.value)\n",
-    "loc_result, ip_entity = iplocation.lookup_ip(ip_address='90.156.201.97')\n",
-    "print('Raw result')\n",
-    "display(loc_result)\n",
     "\n",
-    "print('IP Address Entity')\n",
-    "display(ip_entity[0])"
+    "if \"MSTICPY_SKIP_IPSTACK_TEST\" not in os.environ:\n",
+    "    loc_result, ip_entity = iplocation.lookup_ip(ip_address='90.156.201.97')\n",
+    "    print('Raw result')\n",
+    "    display(loc_result)\n",
+    "\n",
+    "    print('IP Address Entity')\n",
+    "    display(ip_entity[0])"
    ]
   },
   {
@@ -868,12 +871,13 @@
     }
    ],
    "source": [
-    "loc_result, ip_entities = iplocation.lookup_ip(ip_addr_list=ips)\n",
-    "print('Raw results')\n",
-    "display(loc_result)\n",
+    "if \"MSTICPY_SKIP_IPSTACK_TEST\" not in os.environ:\n",
+    "    loc_result, ip_entities = iplocation.lookup_ip(ip_addr_list=ips)\n",
+    "    print('Raw results')\n",
+    "    display(loc_result)\n",
     "\n",
-    "print('IP Address Entities')\n",
-    "display(ip_entities)"
+    "    print('IP Address Entities')\n",
+    "    display(ip_entities)"
    ]
   },
   {

--- a/docs/source/msticpy.vis.rst
+++ b/docs/source/msticpy.vis.rst
@@ -20,7 +20,7 @@ msticpy.vis.mp\_pandas\_plot module
 
 
 msticpy.vis.entity\_graph\_tools module
------------------------------------
+---------------------------------------
 
 .. automodule:: msticpy.vis.entity_graph_tools
     :members:

--- a/msticpy/_version.py
+++ b/msticpy/_version.py
@@ -1,2 +1,2 @@
 """Version file."""
-VERSION = "1.4.5"
+VERSION = "1.5.0pre1"

--- a/msticpy/common/azure_auth_core.py
+++ b/msticpy/common/azure_auth_core.py
@@ -27,7 +27,12 @@ from .._version import VERSION
 from .cred_wrapper import CredentialWrapper
 from .exceptions import MsticpyAzureConnectionError
 from ..common import pkg_config as config
-from .cloud_mappings import get_all_endpoints, get_all_suffixes
+from .cloud_mappings import (
+    get_all_endpoints,
+    get_all_suffixes,
+    CLOUD_ALIASES,
+    CLOUD_MAPPING,
+)
 
 __version__ = VERSION
 __author__ = "Pete Bryan"
@@ -79,6 +84,22 @@ class AzureCloudConfig:
             )
         except KeyError:
             pass  # no Azure section in config
+
+    @property
+    def cloud_names(self) -> List[str]:
+        """Return a list of current cloud names."""
+        return list(CLOUD_MAPPING.keys())
+
+    @staticmethod
+    def resolve_cloud_alias(alias) -> Optional[str]:
+        """Return match of cloud alias or name."""
+        alias_cf = alias.casefold()
+        aliases = {alias.casefold(): cloud for alias, cloud in CLOUD_ALIASES.items()}
+        if alias_cf in aliases:
+            return aliases[alias_cf]
+        if alias_cf in aliases.values():
+            return alias_cf
+        return None
 
     @property
     def endpoints(self) -> azure_cloud.CloudEndpoints:

--- a/msticpy/common/cloud_mappings.py
+++ b/msticpy/common/cloud_mappings.py
@@ -12,14 +12,14 @@ from .exceptions import MsticpyAzureConfigError
 __version__ = VERSION
 __author__ = "Pete Bryan"
 
-_CLOUD_MAPPING = {
+CLOUD_MAPPING = {
     "global": azure_cloud.AZURE_PUBLIC_CLOUD,
     "usgov": azure_cloud.AZURE_US_GOV_CLOUD,
     "de": azure_cloud.AZURE_GERMAN_CLOUD,
     "cn": azure_cloud.AZURE_CHINA_CLOUD,
 }
 
-_CLOUD_ALIASES = {"public": "global", "gov": "usgov", "germany": "de", "china": "cn"}
+CLOUD_ALIASES = {"public": "global", "gov": "usgov", "germany": "de", "china": "cn"}
 
 
 def create_cloud_suf_dict(suffix: str) -> dict:
@@ -39,7 +39,7 @@ def create_cloud_suf_dict(suffix: str) -> dict:
     """
     return {
         cloud: getattr(msr_cloud.suffixes, suffix)
-        for cloud, msr_cloud in _CLOUD_MAPPING.items()
+        for cloud, msr_cloud in CLOUD_MAPPING.items()
     }
 
 
@@ -60,7 +60,7 @@ def create_cloud_ep_dict(endpoint: str) -> dict:
     """
     return {
         cloud: getattr(msr_cloud.endpoints, endpoint)
-        for cloud, msr_cloud in _CLOUD_MAPPING.items()
+        for cloud, msr_cloud in CLOUD_MAPPING.items()
     }
 
 
@@ -84,9 +84,9 @@ def get_all_endpoints(cloud: str) -> azure_cloud.CloudEndpoints:
         If the cloud name is not valid.
 
     """
-    cloud = _CLOUD_ALIASES.get(cloud, cloud)
+    cloud = CLOUD_ALIASES.get(cloud, cloud)
     try:
-        endpoints = _CLOUD_MAPPING[cloud].endpoints
+        endpoints = CLOUD_MAPPING[cloud].endpoints
     except KeyError as cloud_err:
         raise MsticpyAzureConfigError(
             f"""{cloud} is not a valid Azure cloud name.
@@ -115,9 +115,9 @@ def get_all_suffixes(cloud: str) -> azure_cloud.CloudSuffixes:
         If the cloud name is not valid.
 
     """
-    cloud = _CLOUD_ALIASES.get(cloud, cloud)
+    cloud = CLOUD_ALIASES.get(cloud, cloud)
     try:
-        endpoints = _CLOUD_MAPPING[cloud].suffixes
+        endpoints = CLOUD_MAPPING[cloud].suffixes
     except KeyError as cloud_err:
         raise MsticpyAzureConfigError(
             f"""{cloud} is not a valid Azure cloud name.

--- a/msticpy/data/data_providers.py
+++ b/msticpy/data/data_providers.py
@@ -81,7 +81,7 @@ class QueryProvider:
         if driver is None:
             driver_class = import_driver(data_environment)
             if issubclass(driver_class, DriverBase):
-                driver = driver_class(**kwargs)  # type: ignore
+                driver = driver_class(data_environment=data_environment, **kwargs)
             else:
                 raise LookupError(
                     "Could not find suitable data provider for", f" {self.environment}"

--- a/msticpy/data/drivers/__init__.py
+++ b/msticpy/data/drivers/__init__.py
@@ -20,6 +20,7 @@ _ENVIRONMENT_DRIVERS = {
     DataEnvironment.LogAnalytics: ("kql_driver", "KqlDriver"),
     DataEnvironment.AzureSecurityCenter: ("kql_driver", "KqlDriver"),
     DataEnvironment.SecurityGraph: ("security_graph_driver", "SecurityGraphDriver"),
+    DataEnvironment.Kusto: ("kql_driver", "KqlDriver"),
     DataEnvironment.MDATP: ("mdatp_driver", "MDATPDriver"),
     DataEnvironment.MDE: ("mdatp_driver", "MDATPDriver"),
     DataEnvironment.LocalData: ("local_data_driver", "LocalDataDriver"),
@@ -27,6 +28,7 @@ _ENVIRONMENT_DRIVERS = {
     DataEnvironment.Mordor: ("mordor_driver", "MordorDriver"),
     DataEnvironment.Sumologic: ("sumologic_driver", "SumologicDriver"),
     DataEnvironment.ResourceGraph: ("resource_graph_driver", "ResourceGraphDriver"),
+    DataEnvironment.MD365: ("mdatp_driver", "MDATPDriver"),
 }
 
 

--- a/msticpy/data/drivers/kql_driver.py
+++ b/msticpy/data/drivers/kql_driver.py
@@ -24,6 +24,7 @@ from ...common.exceptions import (
 )
 from ...common.wsconfig import WorkspaceConfig
 from ...common.utility import export
+from ..query_defns import DataEnvironment
 from .driver_base import DriverBase, QuerySource
 
 try:
@@ -92,7 +93,7 @@ class KqlDriver(DriverBase):
             self._load_kql_magic()
 
         self._schema: Dict[str, Any] = {}
-
+        self.environment = kwargs.get("data_environment", DataEnvironment.MSSentinel)
         self.kql_cloud, self.az_cloud = self._set_kql_cloud()
 
         if connection_str:
@@ -116,10 +117,10 @@ class KqlDriver(DriverBase):
         mp_az_auth : Union[bool, str, list, None], optional
             Optional parameter directing KqlMagic to use MSTICPy Azure authentication.
             Values can be:
-            - True or "default": use the settings in msticpyconfig.yaml 'Azure' section
-            - auth_method: single auth method name ('msi', 'cli', 'env' or 'interactive')
-            - auth_methods: list of acceptable auth methods from ('msi', 'cli',
-              'env' or 'interactive')
+            True or "default": use the settings in msticpyconfig.yaml 'Azure' section
+            str: single auth method name ('msi', 'cli', 'env' or 'interactive')
+            List[str]: list of acceptable auth methods from ('msi', 'cli',
+            'env' or 'interactive')
 
         """
         print("Connecting...", end=" ")
@@ -127,7 +128,7 @@ class KqlDriver(DriverBase):
             connection_str = connection_str.code_connect_str
         if not connection_str:
             raise MsticpyKqlConnectionError(
-                "A connection string is needed to connect to Azure Sentinel.",
+                f"A connection string is needed to connect to {self._connect_target}",
                 title="no connection string",
             )
         if "kqlmagic_args" in kwargs:
@@ -206,7 +207,7 @@ class KqlDriver(DriverBase):
                 if table not in self.schema:
                     raise MsticpyNoDataSourceError(
                         f"The table {table} for this query is not in your workspace",
-                        " schema. Please check your workspace",
+                        " or database schema. Please check your this",
                         title=f"{table} not found.",
                     )
         data, result = self.query_with_results(query)
@@ -236,7 +237,7 @@ class KqlDriver(DriverBase):
         if not self.connected:
             raise MsticpyNotConnectedError(
                 "Please run the connect() method before running a query.",
-                title="not connected to a workspace.",
+                title=f"not connected to a {self._connect_target}",
                 help_uri=MsticpyKqlConnectionError.DEF_HELP_URI,
             )
 
@@ -292,6 +293,12 @@ class KqlDriver(DriverBase):
         if self._ip is not None:
             return self._ip.find_magic("kql") is not None
         return bool(kql_exec("--version"))
+
+    @property
+    def _connect_target(self) -> str:
+        if self.environment == DataEnvironment.MSSentinel:
+            return "Workspace"
+        return "Kusto cluster"
 
     @staticmethod
     def _get_schema() -> Dict[str, Dict]:
@@ -397,7 +404,8 @@ class KqlDriver(DriverBase):
         """Raise an authentication error."""
         ex_mssgs = [
             "The authentication failed.",
-            "Please check the credentials you are using and permissions on the workspace",
+            "Please check the credentials you are using and permissions on the ",
+            "workspace or cluster.",
             *(ex.args),
         ]
         raise MsticpyKqlConnectionError(*ex_mssgs, title="authentication failed")

--- a/msticpy/data/drivers/kql_driver.py
+++ b/msticpy/data/drivers/kql_driver.py
@@ -258,9 +258,10 @@ class KqlDriver(DriverBase):
         if result is not None:
             if isinstance(result, pd.DataFrame):
                 return result, None
-            if (
-                hasattr(result, "completion_query_info")
-                and result.completion_query_info["StatusCode"] == 0
+            if hasattr(result, "completion_query_info") and (
+                result.completion_query_info.get("StatusCode") == 0
+                or result.completion_query_info.get("Text")
+                == "Query completed successfully"
             ):
                 data_frame = result.to_dataframe()
                 if result.is_partial_table:

--- a/msticpy/data/drivers/mdatp_driver.py
+++ b/msticpy/data/drivers/mdatp_driver.py
@@ -8,6 +8,8 @@ from typing import Union, Any
 import pandas as pd
 
 from .odata_driver import OData, QuerySource
+from ..query_defns import DataEnvironment
+from ...common.azure_auth import AzureCloudConfig
 from ...common.utility import export
 from ..._version import VERSION
 
@@ -17,11 +19,11 @@ __author__ = "Pete Bryan"
 
 @export
 class MDATPDriver(OData):
-    """KqlDriver class to retreive date from MDATP."""
+    """KqlDriver class to retreive date from MS Defender APIs."""
 
     def __init__(self, connection_str: str = None, **kwargs):
         """
-        Instantiaite MDATPDriver and optionally connect.
+        Instantiate MSDefenderDriver and optionally connect.
 
         Parameters
         ----------
@@ -30,15 +32,19 @@ class MDATPDriver(OData):
 
         """
         super().__init__()
+        api_uri, oauth_uri, api_suffix = _select_api_uris(
+            data_environment=kwargs.get("data_environment")
+        )
         self.req_body = {
             "client_id": None,
             "client_secret": None,
             "grant_type": "client_credentials",
-            "resource": "https://api.securitycenter.microsoft.com",
+            "resource": api_uri,
         }
-        self.oauth_url = "https://login.windows.net/{tenantId}/oauth2/token"
-        self.api_root = "https://api.securitycenter.microsoft.com/"
+        self.oauth_url = oauth_uri
+        self.api_root = api_uri
         self.api_ver = "api"
+        self.api_suffix = api_suffix
 
         if connection_str:
             self.current_connection = connection_str
@@ -65,6 +71,21 @@ class MDATPDriver(OData):
 
         """
         del query_source, kwargs
-        return self.query_with_results(
-            query, body=True, api_end="/advancedqueries/run"
-        )[0]
+        return self.query_with_results(query, body=True, api_end=self.api_suffix)[0]
+
+
+def _select_api_uris(data_environment):
+    """Return API and login URIs for selected provider type."""
+    cloud_config = AzureCloudConfig()
+    login_uri = cloud_config.endpoints.active_directory
+    if data_environment == DataEnvironment.MD365:
+        return (
+            "https://api.security.microsoft.com",
+            f"{login_uri}/{{tenantId}}/oauth2/token",
+            "/advancedhunting/run",
+        )
+    return (
+        "https://api.securitycenter.microsoft.com",
+        f"{login_uri}/{{tenantId}}/oauth2/token",
+        "/advancedqueries/run",
+    )

--- a/msticpy/data/drivers/security_graph_driver.py
+++ b/msticpy/data/drivers/security_graph_driver.py
@@ -8,6 +8,7 @@ from typing import Union, Any
 import pandas as pd
 
 from .odata_driver import OData, QuerySource
+from ...common.azure_auth_core import AzureCloudConfig
 from ...common.utility import export
 from ..._version import VERSION
 
@@ -21,7 +22,7 @@ class SecurityGraphDriver(OData):
 
     def __init__(self, connection_str: str = None, **kwargs):
         """
-        Instantiaite KqlDriver and optionally connect.
+        Instantiate KqlDriver and optionally connect.
 
         Parameters
         ----------
@@ -29,17 +30,18 @@ class SecurityGraphDriver(OData):
             Connection string
 
         """
+        azure_cloud = AzureCloudConfig()
         super().__init__()
         self.req_body = {
             "client_id": None,
             "client_secret": None,
             "grant_type": "client_credentials",
-            "scope": "https://graph.microsoft.com/.default",
+            "scope": f"{azure_cloud.endpoints.microsoft_graph_resource_id}/.default",
         }
         self.oauth_url = (
-            "https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token"
+            f"{azure_cloud.endpoints.active_directory}/" "{tenantId}/oauth2/v2.0/token"
         )
-        self.api_root = "https://graph.microsoft.com/"
+        self.api_root = azure_cloud.endpoints.microsoft_graph_resource_id
         self.api_ver = kwargs.get("api_ver", "v1.0")
 
         if connection_str:

--- a/msticpy/data/queries/graph_alerts.yaml
+++ b/msticpy/data/queries/graph_alerts.yaml
@@ -117,9 +117,9 @@ sources:
     args:
       query: '{path}?$filter=createdDateTime ge {start}
         and createdDateTime le {end}
-        and (fileStates/any(d:tolower(fileHash/hashValue) eq tolower("{file_hash}")
-        or fileStates/any(d:tolower(name) eq tolower("{file_path}")
-        or (file_name neq "" and fileStates/any(d:endswith(tolower("{file_name}"), tolower(name)))))
+        and (fileStates/any(d:tolower(d/fileHash/hashValue) eq tolower("{file_hash}")
+        or fileStates/any(d:tolower(d/name) eq tolower("{file_path}")
+        or (file_name neq "" and fileStates/any(d:endswith(tolower("{file_name}"), tolower(d/name)))))
         {add_query_items}'
       uri: None
     parameters:
@@ -146,7 +146,7 @@ sources:
         or hostStates/any(d:d/publicIpAddress eq "{ip_address}")
         or networkConnections/any(d:d/destinationAddress eq "{ip_address}")
         or networkConnections/any(d:d/sourceAddress eq "{ip_address}")
-        or fileStates/any(d:tolower(fileHash/hashValue) eq tolower("{file_hash}")
+        or fileStates/any(d:tolower(d/fileHash/hashValue) eq tolower("{file_hash}")
         or fileStates/any(d:tolower(name) eq tolower("{file_name}")
         or hostStates/any(d:tolower(d/netBiosName) eq tolower("{host_name}")
         or hostStates/any(d:startswith(tolower("{host_name}"), tolower(d/fqdn)))

--- a/msticpy/data/query_defns.py
+++ b/msticpy/data/query_defns.py
@@ -83,6 +83,7 @@ class DataEnvironment(Enum):
     Unknown = 0
     AzureSentinel = 1  # alias of LogAnalytics
     LogAnalytics = 1
+    MSSentinel = 1
     Kusto = 2
     AzureSecurityCenter = 3
     SecurityGraph = 4
@@ -93,6 +94,7 @@ class DataEnvironment(Enum):
     Mordor = 8
     ResourceGraph = 9
     Sumologic = 10
+    MD365 = 11
 
     @classmethod
     def parse(cls, value: Union[str, int]) -> "DataEnvironment":

--- a/msticpy/sectools/proc_tree_builder.py
+++ b/msticpy/sectools/proc_tree_builder.py
@@ -199,7 +199,29 @@ MDE_EVENT_SCH = ProcSchema(
     host_name_column="ComputerDnsName",
 )
 
-SUPPORTED_SCHEMAS = (WIN_EVENT_SCH, LX_EVENT_SCH, MDE_EVENT_SCH)
+# Sentinel DeviceProcessEvents schema
+# Only used for identifying input table.
+_MDE_SENTINEL_EVENT_SCH = ProcSchema(
+    time_stamp="TimeGenerated",
+    process_name="FileName",
+    process_id="ProcessId",
+    parent_name="InitiatingProcessFileName",
+    parent_id="InitiatingProcessParentId",
+    logon_id="InitiatingProcessLogonId",
+    target_logon_id="LogonId",
+    cmd_line="ProcessCommandLine",
+    user_name="AccountName",
+    path_separator="\\",
+    user_id="AccountSid",
+    host_name_column="DeviceName",
+)
+
+SUPPORTED_SCHEMAS = (
+    WIN_EVENT_SCH,
+    LX_EVENT_SCH,
+    MDE_EVENT_SCH,
+    _MDE_SENTINEL_EVENT_SCH,
+)
 
 
 def build_process_tree(
@@ -249,6 +271,9 @@ def build_process_tree(
             "pass it as the 'schema' parameter to this function.",
         )
 
+    if schema == _MDE_SENTINEL_EVENT_SCH:
+        procs = mde.convert_sentinel_to_mde(procs)
+        schema = MDE_EVENT_SCH
     if schema == MDE_EVENT_SCH:
         extr_proc_tree = mde.extract_process_tree(procs, debug=debug)
     else:

--- a/tests/data/drivers/test_kql_driver.py
+++ b/tests/data/drivers/test_kql_driver.py
@@ -16,7 +16,8 @@ from adal.adal_error import AdalError
 from Kqlmagic.kql_response import KqlError
 from Kqlmagic.kql_engine import KqlEngineError
 from Kqlmagic.my_aad_helper import AuthenticationError
-from Kqlmagic import kql as kql_exec
+
+# from Kqlmagic import kql as kql_exec
 
 from msticpy.data.drivers import kql_driver
 from msticpy.common.exceptions import (
@@ -35,7 +36,7 @@ GET_IPYTHON_PATCH = KqlDriver.__module__ + ".get_ipython"
 
 
 # pylint: disable=too-many-branches, too-many-return-statements
-# pylint: disable=no-self-use
+# pylint: disable=no-self-use, redefined-outer-name
 
 
 class KqlResultTest:
@@ -83,6 +84,7 @@ class _MockIPython:
 
 
 def kql_exec(content):
+    """Mock kql_exec function."""
     if "--config" in content:
         if "=" in content:
             conf_item, conf_value = content.replace("--config", "").strip().split("=")
@@ -249,7 +251,7 @@ def test_kql_query_not_connected(get_ipython):
 
     with pytest.raises(MsticpyNotConnectedError) as mp_ex:
         kql_driver.query("test")
-    check.is_in("not connected to a workspace.", mp_ex.value.args)
+    check.is_in("not connected to a Workspace", mp_ex.value.args)
     check.is_false(kql_driver.connected)
 
 

--- a/tests/nbtools/test_azure_ml_tools.py
+++ b/tests/nbtools/test_azure_ml_tools.py
@@ -47,7 +47,7 @@ _MP_CONFIG = "msticpyconfig-test.yaml"
 @pytest.fixture(scope="module")
 def aml_file_sys(tmpdir_factory):
     """Create fake aml file system."""
-    mp_text = Path("tests").joinpath(_MP_CONFIG).read_text()
+    mp_text = Path("tests").joinpath(_MP_CONFIG).read_text(encoding="utf-8")
     root = tmpdir_factory.mktemp("aml-test")
     users = root.mkdir("Users")
     user_dir = users.mkdir("aml_user")
@@ -61,8 +61,9 @@ def aml_file_sys(tmpdir_factory):
     yield users, user_dir
 
 
-_MP_FUT_VER = ".".join(f"{int(v) + 1}" for v in aml.__version__.split("."))
-_MP_FUT_VER_T = tuple(int(v) + 1 for v in aml.__version__.split("."))
+_CURR_VERSION = [v for v in aml.__version__.split(".") if v.isnumeric()]
+_MP_FUT_VER = ".".join(f"{int(v) + 1}" for v in _CURR_VERSION)
+_MP_FUT_VER_T = tuple(int(v) + 1 for v in _CURR_VERSION)
 
 _EXP_ENV = {
     "KQLMAGIC_EXTRAS_REQUIRE": "jupyter-basic",

--- a/tests/sectools/test_geoip.py
+++ b/tests/sectools/test_geoip.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+"""GeoIP provider unit tests."""
 import os
 from pathlib import Path
 import socket
@@ -26,7 +27,7 @@ _MP_CONFIG_PATH = get_test_data_path().parent.joinpath("msticpyconfig-test.yaml"
     not os.environ.get("MSTICPY_TEST_NOSKIP"), reason="Skipped for local tests."
 )
 def test_geoip_notebook():
-    """Test"""
+    """Test geoip notebook."""
     nb_path = Path(_NB_FOLDER).joinpath(_NB_NAME)
     abs_path = Path(_NB_FOLDER).absolute()
 

--- a/tests/sectools/test_geoip.py
+++ b/tests/sectools/test_geoip.py
@@ -26,9 +26,12 @@ _MP_CONFIG_PATH = get_test_data_path().parent.joinpath("msticpyconfig-test.yaml"
     not os.environ.get("MSTICPY_TEST_NOSKIP"), reason="Skipped for local tests."
 )
 def test_geoip_notebook():
+    """Test"""
     nb_path = Path(_NB_FOLDER).joinpath(_NB_NAME)
     abs_path = Path(_NB_FOLDER).absolute()
 
+    if not os.environ.get("MSTICPY_TEST_IPSTACK"):
+        os.environ["MSTICPY_SKIP_IPSTACK_TEST"] = "1"
     with open(nb_path, "rb") as f:
         nb_bytes = f.read()
     nb_text = nb_bytes.decode("utf-8")
@@ -47,6 +50,9 @@ def test_geoip_notebook():
         with open(nb_err, mode="w", encoding="utf-8") as f:
             nbformat.write(nb, f)
         raise
+
+    if os.environ.get("MSTICPY_SKIP_IPSTACK_TEST"):
+        del os.environ["MSTICPY_SKIP_IPSTACK_TEST"]
 
 
 @pytest.mark.skipif(
@@ -100,6 +106,9 @@ def test_geoiplite_lookup():
             check.is_not_none(ip_entity.Location)
 
 
+@pytest.mark.skipif(
+    not os.environ.get("MSTICPY_TEST_IPSTACK"), reason="Skipped ip stack tests."
+)
 def test_ipstack_lookup():
     """Test IPStack lookups."""
     socket_info = socket.getaddrinfo("pypi.org", 0, 0, 0, 0)


### PR DESCRIPTION
Adding support for MD365 in mdatp_driver.py and data/__init__.py
Adding additional enviroment aliases to query_defns.py
Adding support for Kusto clusters in kql_driver.py and data/__init__.py
Exposing CLOUD_ALIASES and CLOUD_MAPPING as public attributes in azure_auth_core.py
DataProviders class now sends environment as a kwarg to driver classes in data_providers.py
Fixing issue in odata_driver.py where api_root would keep getting suffix appended if you connected multiple times.
Adding mutli-cloud support for MS Graph API in security_graph_driver.py
Fixing syntax errors in graph_alerts.yaml
Updating tests for test_drivers and test_kql_driver
Fixing heading underline in msticpy.vis.rst