### PR TITLE
Removing validate configuration for external forks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -276,12 +276,13 @@ stages:
         WebScout: false
     - task: notice@0
       displayName: NOTICE File Generator
+      # This fails for external forks
+      condition: not(variables['System.PullRequest.IsFork'])
     - task: PostAnalysis@1
       displayName: Post Analysis
       inputs:
         CredScan: true
         PoliCheck: true
-      condition: not(variables['System.PullRequest.IsFork'])
     - task: dependency-check-build-task@5
       displayName: 'OWASP Dependency Check'
       inputs:

--- a/tests/common/test_pkg_config.py
+++ b/tests/common/test_pkg_config.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 import warnings
 
+import pytest
 import yaml
 
 from msticpy.common import pkg_config
@@ -89,7 +90,7 @@ class TestPkgConfig(unittest.TestCase):
         test_config1 = Path(_TEST_DATA).joinpath(pkg_config._CONFIG_FILE)
         with custom_mp_config(test_config1):
 
-            with open(test_config1) as f_handle:
+            with open(test_config1, encoding="utf-8") as f_handle:
                 config_settings = yaml.safe_load(f_handle)
             conf_dbpath = (
                 config_settings.get("OtherProviders", {})
@@ -111,6 +112,10 @@ class TestPkgConfig(unittest.TestCase):
             ipstack = IPStackLookup()
             self.assertEqual(ipstack._api_key, "987654321-222")
 
+    @pytest.mark.skipif(
+        os.environ.get("MSTICPY_BUILD_SOURCE").casefold() == "fork",
+        reason="External fork.",
+    )
     def test_validate_config(self):
         """Test config validation function."""
         test_config1 = Path(_TEST_DATA).joinpath(pkg_config._CONFIG_FILE)


### PR DESCRIPTION
Suppressing a test that fails for external forks