### PR TITLE
Fix QueryTime unit change

### DIFF
--- a/msticpy/nbtools/nbwidgets/query_time.py
+++ b/msticpy/nbtools/nbwidgets/query_time.py
@@ -223,6 +223,14 @@ class QueryTime(RegisteredWidget, IPyDisplayMixin):
         self._w_tm_range.value = (-self.before, self.after)
         self._w_tm_range.min = -self.max_before
         self._w_tm_range.max = self.max_after
+        self._query_start = self.origin_time + timedelta(
+            0, self._w_tm_range.value[0] * self._time_unit.value
+        )
+        self._query_end = self.origin_time + timedelta(
+            0, self._w_tm_range.value[1] * self._time_unit.value
+        )
+        self._w_start_time_txt.value = self._query_start.isoformat(sep=" ")
+        self._w_end_time_txt.value = self._query_end.isoformat(sep=" ")
 
     def _get_time_parameters(self, **kwargs):
         """Process different init time parameters."""


### PR DESCRIPTION
We need to make sure we update the actual start/end values when there is a time unit change within the QueryTime widget. Similarly to time range updates. This becomes apparent whenever the unit change isn't accompanied by the default time range change (e.g. days -> weeks).