### PR TITLE
Merging changes from main for geoip.py, config editor and kusto_driver

### DIFF
--- a/msticpy/common/pkg_config.py
+++ b/msticpy/common/pkg_config.py
@@ -210,11 +210,11 @@ def _get_custom_config():
     config_path = os.environ.get(_CONFIG_ENV_VAR, None)
     if config_path and Path(config_path).is_file():
         _CURRENT_CONF_FILE(str(Path(config_path).resolve()))
-        return _read_config_file(config_path)
+        return _read_config_file(current_config_path())
 
     if Path(_CONFIG_FILE).is_file():
         _CURRENT_CONF_FILE(str(Path(".").joinpath(_CONFIG_FILE).resolve()))
-        return _read_config_file(_CONFIG_FILE)
+        return _read_config_file(current_config_path())
     return {}
 
 

--- a/msticpy/config/mp_config_control.py
+++ b/msticpy/config/mp_config_control.py
@@ -26,16 +26,14 @@ STORE_ENV_VAR = "EnvironmentVar"
 STORE_KEYVAULT = "KeyVault"
 STORE_OPT = "StoreType"
 
-ValidtnResult = namedtuple("ValidtnResult", "result, status")
-_VALID_SUCESS = "Validation succeeded"
+ValidationResult = namedtuple("ValidationResult", "result, status")
+_VALID_SUCCESS = "Validation succeeded"
 
 
 class MpConfigControls:
     """Msticpy configuration and settings database."""
 
-    def __init__(
-        self, mp_config_def: Dict[str, Any], mp_config: Optional[Dict[str, Any]] = None
-    ):
+    def __init__(self, mp_config_def: Dict[str, Any], mp_config: Dict[str, Any]):
         """
         Return an instance of MpConfigControls.
 
@@ -43,11 +41,11 @@ class MpConfigControls:
         ----------
         mp_config_def : Dict[str, Any]
             Msticpy config setting definitions.
-        mp_config : Optional[Dict[str, Any]], optional
-            Msticpy Settings dictionary, by default None
+        mp_config : Dict[str, Any]
+            Msticpy Settings dictionary
 
         """
-        self.mp_config = mp_config or {}
+        self.mp_config = mp_config
         self._raw_config_defn = mp_config_def
         self.config_defn = self._convert_mp_config(mp_config_def)
         self.controls = self._create_ctrl_dict(self.mp_config)
@@ -224,7 +222,7 @@ class MpConfigControls:
                 ctrl_dict[name] = None
         return ctrl_dict
 
-    def validate_all_settings(self, show_all: bool = False) -> List[ValidtnResult]:
+    def validate_all_settings(self, show_all: bool = False) -> List[ValidationResult]:
         """
         Validate settings against definitions.
 
@@ -248,7 +246,7 @@ class MpConfigControls:
 
     def validate_setting(
         self, path: str, defn_path: Optional[str] = None, show_all: bool = False
-    ) -> List[ValidtnResult]:
+    ) -> List[ValidationResult]:
         """
         Validate settings against definitions for a specific path.
 
@@ -277,9 +275,9 @@ class MpConfigControls:
         if isinstance(results, list):
             up_results = self._unpack_lists(results)
             return [res for res in up_results if not res[0] or show_all]
-        return [ValidtnResult(True, "No validation results found")]
+        return [ValidationResult(True, "No validation results found")]
 
-    def _unpack_lists(self, res_list: List[Any]) -> List[ValidtnResult]:
+    def _unpack_lists(self, res_list: List[Any]) -> List[ValidationResult]:
         """Unpack nested lists into a single list."""
         results = []
         for item in res_list:
@@ -292,7 +290,7 @@ class MpConfigControls:
     # pylint: disable=too-many-return-statements
     def _validate_setting_at_path(
         self, path: str, defn_path: Optional[str] = None, index: Optional[int] = None
-    ) -> Union[ValidtnResult, List[Union[ValidtnResult, List[Any]]]]:
+    ) -> Union[ValidationResult, List[Union[ValidationResult, List[Any]]]]:
         """Recursively validate settings at path."""
         defn_path = defn_path or path
         conf_defn = self.get_defn(defn_path)
@@ -305,12 +303,12 @@ class MpConfigControls:
 
         # If we don't have a definition, there's nothing to validate against.
         if not conf_defn:
-            return ValidtnResult(True, f"No definition for path '{path}'")
+            return ValidationResult(True, f"No definition for path '{path}'")
 
         # If this is None and we're not at a leaf setting it means the
         # settings path doesn't exist, so bail here.
         if not setting and not isinstance(conf_defn, tuple):
-            return ValidtnResult(True, f"No setting at path '{path}'")
+            return ValidationResult(True, f"No setting at path '{path}'")
 
         # if the current defn node is a dict, then we need to recurse
         # into it.
@@ -344,14 +342,14 @@ class MpConfigControls:
             validator = _VALIDATORS.get(val_type)
             if validator:
                 return validator(setting, path, val_type, val_opts)
-            return ValidtnResult(True, "No validator for type '{val_type}'")
+            return ValidationResult(True, "No validator for type '{val_type}'")
 
         # If the conf definition is a literal value - compare directly
         if conf_defn == setting:
-            return ValidtnResult(True, f"Value is valid at path '{path}'")
+            return ValidationResult(True, f"Value is valid at path '{path}'")
 
         # Otherwise, we assume failure.
-        return ValidtnResult(False, f"Validation failed for path '{path}'")
+        return ValidationResult(False, f"Validation failed for path '{path}'")
 
     def _yml_extract_type(self, conf_val):
         """Extract type and options from definition."""
@@ -467,101 +465,101 @@ def _is_none_and_not_required(value, val_type, val_opts):
 def _validate_string(value, path, val_type, val_opts):
     mssg = _get_mssg(value, path)
     if _is_none_and_not_required(value, val_type, val_opts):
-        return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+        return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
     if not isinstance(value, str):
-        return ValidtnResult(
+        return ValidationResult(
             False, f"Value type {type(value)} should be type {val_type} - {mssg}"
         )
     if "options" in val_opts and value not in val_opts["options"]:
-        return ValidtnResult(
+        return ValidationResult(
             False,
             f"Value {value} must be one of {', '.join(val_opts['options'])} - {mssg}",
         )
     if val_opts.get("format") == "uuid" and not is_valid_uuid(value):
-        return ValidtnResult(
+        return ValidationResult(
             False,
             f"Value {value} should be a UUID - {mssg}",
         )
-    return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+    return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
 
 
 def _validate_bool(value, path, val_type, val_opts):
     mssg = _get_mssg(value, path)
     if _is_none_and_not_required(value, val_type, val_opts):
-        return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+        return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
     if not isinstance(value, bool):
-        return ValidtnResult(
+        return ValidationResult(
             False, f"Value type {type(value)} should be type {val_type} - {mssg}"
         )
-    return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+    return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
 
 
 def _validate_m_enum(value, path, val_type, val_opts):
     mssg = _get_mssg(value, path)
     if _is_none_and_not_required(value, val_type, val_opts):
-        return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+        return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
     if not isinstance(value, (str, list)):
-        return ValidtnResult(
+        return ValidationResult(
             False, f"Value type {type(value)} should be type {val_type} - {mssg}"
         )
     if "options" in val_opts:
         if isinstance(value, str) and value not in val_opts["options"]:
-            return ValidtnResult(
+            return ValidationResult(
                 False,
                 f"Value {value} must be one of {', '.join(val_opts['options'])} - {mssg}",
             )
         if not isinstance(value, list):
-            return ValidtnResult(
+            return ValidationResult(
                 False,
                 f"Value '{value}' should be a string or list. "
                 + f"Must be one of {', '.join(val_opts['options'])} - {mssg}",
             )
         invalid_opts = [val for val in value if val not in val_opts["options"]]
         if invalid_opts:
-            return ValidtnResult(
+            return ValidationResult(
                 False,
                 f"Invalid values '{invalid_opts}' found. "
                 + f"Must be one of {', '.join(val_opts['options'])} - {mssg}",
             )
-    return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+    return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
 
 
 def _validate_txt_dict(value, path, val_type, val_opts):
     mssg = _get_mssg(value, path)
     if _is_none_and_not_required(value, val_type, val_opts):
-        return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+        return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
     if isinstance(value, dict):
         for d_key, d_val in value.items():
             if not isinstance(d_key, str):
-                return ValidtnResult(
+                return ValidationResult(
                     False,
                     f"Key {d_key} of {value} must be a string - {mssg}",
                 )
             if not isinstance(d_val, (str, int, bool)):
-                return ValidtnResult(
+                return ValidationResult(
                     False,
                     f"Value {d_val} of key {d_key} in {value} must be a"
                     + f" string, int or bool - {mssg}",
                 )
-        return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
-    return ValidtnResult(False, f"Value {value} should be a dictionary - {mssg}")
+        return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
+    return ValidationResult(False, f"Value {value} should be a dictionary - {mssg}")
 
 
 def _validate_list(value, path, val_type, val_opts):
     mssg = _get_mssg(value, path)
     if _is_none_and_not_required(value, val_type, val_opts):
-        return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+        return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
     if isinstance(value, list):
         for item_val in value:
             expected_type = val_opts.get("elem_type", "str")
             val_type = type(item_val).__name__
             if expected_type != val_type:
-                return ValidtnResult(
+                return ValidationResult(
                     False,
                     f"Item {item_val} of {value} expected to be a {expected_type} - {mssg}",
                 )
-        return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
-    return ValidtnResult(False, f"Value {value} should be a list - {mssg}")
+        return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
+    return ValidationResult(False, f"Value {value} should be a list - {mssg}")
 
 
 def _validate_defn(value, path, val_type, val_opts):
@@ -583,12 +581,12 @@ def _validate_defn(value, path, val_type, val_opts):
     """
     mssg = _get_mssg(value, path)
     if _is_none_and_not_required(value, val_type, val_opts):
-        return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+        return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
 
     # This only handles "one_of" lists of alternatives
     opt_list = val_opts.get("defn", {}).get("one_of")
     if not opt_list:
-        return ValidtnResult(True, f"{_VALID_SUCESS} {mssg}")
+        return ValidationResult(True, f"{_VALID_SUCCESS} {mssg}")
     # pull the definitions (val_type and val_opts) for each item into a dict
     opt_dict = {next(iter(val.keys())): next(iter(val.values())) for val in opt_list}
 
@@ -612,7 +610,7 @@ def _validate_defn(value, path, val_type, val_opts):
             _validator = _VALIDATORS.get(opt_v_type, _validate_string)
             return _validator(v_val, f"{path}.{v_key}", opt_v_type, opt_v_opts)
     # Otherwise the validation failed
-    return ValidtnResult(
+    return ValidationResult(
         False,
         f"Value type {type(value)} does not match definition {val_opts['defn']} - {mssg}",
     )

--- a/msticpy/config/mp_config_edit.py
+++ b/msticpy/config/mp_config_edit.py
@@ -25,6 +25,7 @@ __version__ = VERSION
 __author__ = "Ian Hellen"
 
 
+# pylint: disable=too-many-instance-attributes
 class MpConfigEdit(CompEditDisplayMixin):
     """Msticpy Configuration helper class."""
 
@@ -110,10 +111,13 @@ class MpConfigEdit(CompEditDisplayMixin):
         )
         self.btn_validate.on_click(self._validate_config)
         self.cb_backup = widgets.Checkbox(description="Create backup", value=False)
+        self.cb_refresh = widgets.Checkbox(description="Refresh on save", value=True)
         vbox = widgets.VBox(
             [
                 self.txt_current_file,
-                widgets.HBox([self.btn_save, self.cb_backup, self.btn_validate]),
+                widgets.HBox(
+                    [self.btn_save, self.cb_refresh, self.cb_backup, self.btn_validate]
+                ),
                 self.mp_conf_file.viewer,
             ]
         )
@@ -143,6 +147,8 @@ class MpConfigEdit(CompEditDisplayMixin):
             self.mp_conf_file.save_to_file(
                 self.txt_current_file.value, backup=self.cb_backup.value
             )
+        if self.cb_refresh.value:
+            self.mp_conf_file.refresh_mp_config()
 
     def _validate_config(self, btn):
         del btn

--- a/msticpy/config/mp_config_file.py
+++ b/msticpy/config/mp_config_file.py
@@ -8,6 +8,7 @@
 import io
 import os
 import pprint
+import warnings
 from contextlib import redirect_stdout, suppress
 from datetime import datetime
 from pathlib import Path
@@ -52,12 +53,16 @@ class MpConfigFile(CompEditStatusMixin, CompEditDisplayMixin):
     MSTICPy Configuration management class.
 
     Use the functions from the commandline or display
-    in a Jupter notebook to use interactive version.
+    in a Jupyter notebook to use interactive version.
 
     """
 
+    _DEF_FILENAME = "./msticpyconfig.yaml"
+
     def __init__(
-        self, file: Optional[str] = None, settings: Optional[Dict[str, Any]] = None
+        self,
+        file: Union[str, Path, None] = None,
+        settings: Optional[Dict[str, Any]] = None,
     ):
         """
         Create an instance of the MSTICPy Configuration helper class.
@@ -73,10 +78,6 @@ class MpConfigFile(CompEditStatusMixin, CompEditDisplayMixin):
         self.settings = settings or {}
 
         self.kv_client: Any = None
-        self.mp_config_def_path = os.environ.get(
-            "MSTICPYCONFIG", "./msticpyconfig.yaml"
-        )
-        self._current_file = None
 
         # Set up controls
         self.file_browser = FileBrowser(select_cb=self.load_from_file)
@@ -88,13 +89,10 @@ class MpConfigFile(CompEditStatusMixin, CompEditDisplayMixin):
 
         self.html_title = widgets.HTML("<h3>MSTICPy settings</h3>")
         self.txt_current_file = widgets.Text(description="Current file", **_TXT_STYLE)
-        self.txt_current_file.value = self.current_file or ""
         self.txt_current_file.observe(self._update_curr_file, "value")
         self.txt_curr_mpconfig = widgets.Text(
-            description="Value of MSTICPCONFIG", **_TXT_STYLE
+            description="Value of MSTICPYCONFIG", **_TXT_STYLE
         )
-        self.txt_curr_mpconfig.value = self.mp_config_def_path
-        self.txt_curr_mpconfig.disabled = True
 
         self.buttons: Dict[str, widgets.Button] = {}
         self.btn_pane = self._setup_buttons()
@@ -115,9 +113,31 @@ class MpConfigFile(CompEditStatusMixin, CompEditDisplayMixin):
             layout=self.border_layout("99%"),
         )
 
-        self.current_file = file
-        if file and Path(file).is_file():
-            self.load_from_file(file)
+        self.mp_config_def_path = os.environ.get("MSTICPYCONFIG", None)
+        if (
+            self.mp_config_def_path is not None
+            and not Path(self.mp_config_def_path).is_file()
+        ):
+            warnings.warn(
+                "MSTICPYCONFIG env variable is pointing to invalid path."
+                + self.mp_config_def_path
+            )
+            self.mp_config_def_path = self._DEF_FILENAME
+        if settings is not None:
+            self.current_file = file or self._DEF_FILENAME
+        else:
+            self.current_file = file or self.mp_config_def_path
+
+        self.txt_current_file.value = self.current_file or ""
+
+        if settings is not None:
+            # If caller has supplied settings, we don't want to load
+            # anything from a file
+            return
+        if self.current_file and Path(self.current_file).is_file():
+            self.load_from_file(self.current_file)
+        else:
+            raise ValueError(f"File not found: '{self.current_file}'.")
 
     @property
     def current_file(self):
@@ -126,7 +146,7 @@ class MpConfigFile(CompEditStatusMixin, CompEditDisplayMixin):
 
     @current_file.setter
     def current_file(self, file_name: Union[str, Path]):
-        self._current_file = str(file_name) or None
+        self._current_file = str(file_name)
         self.txt_current_file.value = self._current_file or ""
 
     def _update_curr_file(self, change):
@@ -146,7 +166,7 @@ class MpConfigFile(CompEditStatusMixin, CompEditDisplayMixin):
         if show:
             display(self.viewer)
 
-    def load_from_file(self, file: str):
+    def load_from_file(self, file: Union[str, Path]):
         """Load settings from `file`."""
         self.settings = self._read_mp_config(file)
         self.current_file = file
@@ -327,10 +347,10 @@ class MpConfigFile(CompEditStatusMixin, CompEditDisplayMixin):
         self.buttons["reload"].on_click(self._btn_func("refresh_mp_config"))
         self.buttons["showkv"].on_click(self._btn_func_no_disp("show_kv_secrets"))
 
-        btns1 = widgets.VBox(list(self.buttons.values())[: int(len(self.buttons) / 2)])
+        btns1 = widgets.VBox(list(self.buttons.values())[: len(self.buttons) // 2])
         # flake8: noqa: E203
         # conflicts with Black formatting
-        btns2 = widgets.VBox(list(self.buttons.values())[int(len(self.buttons) / 2) :])
+        btns2 = widgets.VBox(list(self.buttons.values())[len(self.buttons) // 2 :])
         btns_all = widgets.HBox([btns1, btns2])
         return widgets.VBox(
             [widgets.Label(value="Operations"), btns_all],

--- a/msticpy/data/context/geoip.py
+++ b/msticpy/data/context/geoip.py
@@ -19,14 +19,14 @@ rate. Maxmind geolite uses a downloadable database, while IPStack is
 an online lookup (API key required).
 
 """
+
 import math
-import os
 import random
 import tarfile
 import warnings
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from json import JSONDecodeError
 from pathlib import Path
 from time import sleep
@@ -273,6 +273,7 @@ Alternatively, you can pass this to the IPStackLookup class when creating it:
             on free tier API key)
 
         """
+        self._check_valid_config()
         if ip_address and isinstance(ip_address, str):
             ip_list = [ip_address.strip()]
         elif ip_addr_list:
@@ -456,23 +457,17 @@ Alternatively, you can pass this to the GeoLiteLookup class when creating it:
 
         self._debug = debug
         if self._debug:
-            dbg_api_key = (
-                "None" if api_key is None else api_key[:4] + "*" * (len(api_key) - 4)
-            )
-            self._pr_debug(f"__init__ params: api_key={dbg_api_key}")
-            self._pr_debug(f"    db_folder={db_folder}")
-            self._pr_debug(f"    force_update={force_update}")
-            self._pr_debug(f"    auto_update={auto_update}")
+            self._debug_init_state(api_key, db_folder, force_update, auto_update)
         self.settings = _get_geoip_provider_settings("GeoIPLite")
         self._api_key = api_key or self.settings.args.get("AuthKey")
 
-        self._dbfolder = db_folder
-        if self._dbfolder is None:
-            self._dbfolder = self.settings.args.get("DBFolder", self._DB_HOME)
-        self._dbfolder = str(Path(self._dbfolder).expanduser())  # type: ignore
+        self._db_folder: str = db_folder or self.settings.args.get(  # type: ignore
+            "DBFolder", self._DB_HOME
+        )
+        self._db_folder = str(Path(self._db_folder).expanduser())  # type: ignore
         self._force_update = force_update
         self._auto_update = auto_update
-        self._dbpath: Optional[str] = None
+        self._db_path: Optional[str] = None
         self._reader: Any = None
 
     def close(self):
@@ -557,154 +552,73 @@ Alternatively, you can pass this to the GeoLiteLookup class when creating it:
         ip_entity.Location = geo_entity
         return ip_entity
 
-    def _pr_debug(self, *args):
-        """Print out debug info."""
-        if self._debug:
-            print(*args)
-
-    @staticmethod
-    def _geolite_warn(messages: List[str]):
-        warn_message = "\n".join(messages)
-        warnings.warn(
-            f"GeoIpLookup: warnings detected: {warn_message}",
-            UserWarning,
-        )
-
     def _check_db_open(self):
         """Check if DB reader open with a valid database."""
         if self._reader:
             return
-        self._check_and_update_db(self._dbfolder, self._force_update, self._auto_update)
-        self._dbpath = self._get_geoip_dbpath(self._dbfolder)
+        self._check_and_update_db()
+        self._db_path = self._get_geoip_db_path()
         if self._debug:
-            dbg_api_key = (
-                "None"
-                if self._api_key is None
-                else self._api_key[:4] + "*" * (len(self._api_key) - 4)
-            )
-            self._pr_debug(f"__init__ values (inc settings): api_key={dbg_api_key}")
-            self._pr_debug(f"    db_folder={self._dbfolder}")
-            self._pr_debug(f"    force_update={self._force_update}")
-            self._pr_debug(f"    auto_update={self._auto_update}")
-            self._pr_debug(f"    dbpath={self._dbpath}")
-            self._pr_debug(f"Using config file: {current_config_path()}")
+            self._debug_open_state()
 
-        if not self._dbpath:
-            raise MsticpyUserConfigError(
-                "No usable GeoIP Database could be found.",
-                (
-                    "Check that you have correctly configured the Maxmind API key in "
-                    "msticpyconfig.yaml."
-                ),
-                (
-                    "If you are using a custom DBFolder setting in your config, "
-                    + f"check that this is a valid path: {self._dbfolder}."
-                ),
-                (
-                    "If you edit your msticpyconfig to change this setting run the "
-                    "following commands to reload your settings and retry:"
-                    "    import msticpy"
-                    "    msticpy.settings.refresh_config()"
-                ),
-                help_uri=(
-                    "https://msticpy.readthedocs.io/en/latest/data_acquisition/"
-                    + "GeoIPLookups.html#maxmind-geo-ip-lite-lookup-class"
-                ),
-                service_uri="https://www.maxmind.com/en/geolite2/signup",
-                title="Maxmind GeoIP database not found",
-            )
-        self._reader = geoip2.database.Reader(self._dbpath)
+        if not self._db_path:
+            self._raise_no_db_error()
+        self._reader = geoip2.database.Reader(self._db_path)
 
-    def _check_and_update_db(
-        self,
-        db_folder: str = None,
-        force_update: bool = False,
-        auto_update: bool = True,
-    ):
-        r"""
+    def _check_and_update_db(self):
+        """
         Check the age of geo ip database file and download if it older than 30 days.
 
         User can set auto_update or force_update to True or False to
         override auto-download behavior.
 
-        Parameters
-        ----------
-        db_folder: str, optional
-            Provide absolute path to the folder containing MMDB file
-            (e.g. '/usr/home' or 'C:\maxmind').
-            If no path provided, it is set to download to .msticpy\GeoLite2 dir under
-            user`s home directory.
-        force_update : bool, optional
-            Force update can be set to true or false. depending on it,
-            new download request will be initiated, overriding age criteria.
-        auto_update : bool, optional
-            Auto update can be set to true or false. depending on it,
-            new download request will be initiated if age criteria is matched.
-
         """
-        geoip_db_path = self._get_geoip_dbpath(db_folder)
-        url = self._MAXMIND_DOWNLOAD.format(license_key=self._api_key)
+        geoip_db_path = self._get_geoip_db_path()
         self._pr_debug(f"Checking geoip DB {geoip_db_path}")
         self._pr_debug(f"Download URL is {self._MAXMIND_DOWNLOAD}")
         if geoip_db_path is None:
             print(
                 "No local Maxmind City Database found. ",
-                f"Attempting to downloading new database to {db_folder}",
+                f"Attempting to downloading new database to {self._db_folder}",
             )
-            self._download_and_extract_archive(url, db_folder)
-            return
+            self._download_and_extract_archive()
+        else:
+            # Create a reader object to retrive db info and build date
+            # to check age from build_epoch property.
+            with geoip2.database.Reader(geoip_db_path) as reader:
+                last_mod_time = datetime.fromtimestamp(
+                    reader.metadata().build_epoch, tz=timezone.utc
+                )
 
-        warn_messages: List[str] = []
-        # Create a reader object to retrive db info and build date
-        # to check age from build_epoch property.
-        with geoip2.database.Reader(geoip_db_path) as reader:
-            last_mod_time = datetime.utcfromtimestamp(reader.metadata().build_epoch)
+            # Check for out of date DB file according to db_age
+            db_age = datetime.now(timezone.utc) - last_mod_time
+            db_updated = True
+            if db_age > timedelta(30) and self._auto_update:
+                print(
+                    "Latest local Maxmind City Database present is older than 30 days.",
+                    f"Attempting to download new database to {self._db_folder}",
+                )
+                if not self._download_and_extract_archive():
+                    self._geolite_warn("DB download failed")
+                    db_updated = False
+            elif self._force_update:
+                print(
+                    "force_update is set to True.",
+                    f"Attempting to download new database to {self._db_folder}",
+                )
+                if not self._download_and_extract_archive():
+                    self._geolite_warn("DB download failed")
+                    db_updated = False
+            if not db_updated:
+                self._geolite_warn(
+                    "Continuing with cached database. Results may inaccurate."
+                )
 
-        # Check for out of date DB file according to db_age
-        db_age = datetime.utcnow() - last_mod_time
-        db_updated = True
-        if db_age > timedelta(30) and auto_update:
-            print(
-                "Latest local Maxmind City Database present is older than 30 days.",
-                f"Attempting to download new database to {db_folder}",
-            )
-            if not self._download_and_extract_archive(url, db_folder):
-                self._pr_debug("DB download failed")
-                warn_messages.append("DB download failed")
-                db_updated = False
-        elif force_update:
-            print(
-                "force_update is set to True.",
-                f"Attempting to download new database to {db_folder}",
-            )
-            if not self._download_and_extract_archive(url, db_folder):
-                self._pr_debug("DB download failed")
-                warn_messages.append("DB download failed")
-                db_updated = False
-        if not db_updated:
-            self._pr_debug("Continuing with cached database.")
-            warn_messages.append(
-                "Continuing with cached database. Results may inaccurate."
-            )
-        if warn_messages:
-            self._geolite_warn(warn_messages)
-
+    # noqa: MC0001
     # pylint: disable=too-many-branches
-    def _download_and_extract_archive(  # noqa: MC0001
-        self, url: str = None, db_folder: str = None  # noqa: MC0001
-    ) -> bool:
-        r"""
+    def _download_and_extract_archive(self) -> bool:  # noqa: MC0001
+        """
         Download file from the given URL and extract if it is archive.
-
-        Parameters
-        ----------
-        url : str
-            Web URL location to the Maxmind city Database. (the default is None)
-        db_folder: str, optional
-            Provide absolute path to the folder containing MMDB file
-            (e.g. '/usr/home' or 'C:\maxmind').
-            If no path provided, it is set to download to .msticpy dir under
-            user`s home directory.(the default is None)
 
         Returns
         -------
@@ -714,19 +628,14 @@ Alternatively, you can pass this to the GeoLiteLookup class when creating it:
         """
         if not self._api_key:
             return False
-        if url is None:
-            url = self._MAXMIND_DOWNLOAD.format(license_key=self._api_key)
+        url = self._MAXMIND_DOWNLOAD.format(license_key=self._api_key)
 
-        if db_folder is None:
-            db_folder = self._DB_HOME
-
-        warn_messages: List[str] = []
-
-        if not Path(db_folder).exists():
-            # using makedirs to create intermediate-level dirs to contain the leaf dir
-            Path(db_folder).mkdir(exist_ok=True, parents=True)
+        if not Path(self._db_folder).exists():
+            # using makedirs to create intermediate-level dirs to contain self._dbfolder
+            Path(self._db_folder).mkdir(exist_ok=True, parents=True)
+        # build a temp file name for the archive download
         rand_int = random.randint(10000, 99999)  # nosec
-        db_archive_path = Path(db_folder).joinpath(
+        db_archive_path = Path(self._db_folder).joinpath(
             self._DB_ARCHIVE.format(rand=rand_int)
         )
         self._pr_debug(f"Downloading GeoLite DB: {db_archive_path}")
@@ -734,8 +643,9 @@ Alternatively, you can pass this to the GeoLiteLookup class when creating it:
             # wait a small rand amount of time in case multiple procs try
             # to download simultaneously
             sleep(rand_int / 500000)
-            if list(Path(db_folder).glob(self._DB_ARCHIVE.format(rand="*"))):
-                # Some other process is downloading
+            if list(Path(self._db_folder).glob(self._DB_ARCHIVE.format(rand="*"))):
+                # Some other process is downloading, wait a little then return
+                sleep(3)
                 return True
             with httpx.stream(
                 "GET", url, timeout=httpx.Timeout(10.0, connect=30.0)
@@ -747,31 +657,25 @@ Alternatively, you can pass this to the GeoLiteLookup class when creating it:
                         file_hdl.flush()
             self._pr_debug(f"Downloaded GeoLite DB: {db_archive_path}")
         except httpx.HTTPError as http_err:
-            self._pr_debug(
-                f"HTTP error occurred trying to download GeoLite DB: {http_err}"
-            )
-            warn_messages.append(
+            self._geolite_warn(
                 f"HTTP error occurred trying to download GeoLite DB: {http_err}"
             )
         # pylint: disable=broad-except
         except Exception as err:
-            self._pr_debug(f"Other error occurred trying to download GeoLite DB: {err}")
-            warn_messages.append(
+            self._geolite_warn(
                 f"Other error occurred trying to download GeoLite DB: {err}"
             )
         # pylint: enable=broad-except
         else:
+            # no exceptions so extract the archive contents
             try:
-                self._extract_to_folder(db_archive_path, db_folder)
+                self._extract_to_folder(db_archive_path)
                 print(
                     "Extraction complete. Local Maxmind city DB:", f"{db_archive_path}"
                 )
                 return True
             except PermissionError as err:
-                self._pr_debug(
-                    f"Error writing GeoIP DB file: {db_archive_path} - {err}"
-                )
-                warn_messages.append(
+                self._geolite_warn(
                     f"Cannot overwrite GeoIP DB file: {db_archive_path}."
                     + " The file may be in use or you do not have"
                     + f" permission to overwrite.\n - {err}"
@@ -779,55 +683,49 @@ Alternatively, you can pass this to the GeoLiteLookup class when creating it:
             except Exception as err:  # pylint: disable=broad-except
                 # There are several exception types that might come from
                 # unpacking a tar.gz
-                self._pr_debug(
-                    f"Error writing GeoIP DB file: {db_archive_path} - {err}"
-                )
-                warn_messages.append(
+                self._geolite_warn(
                     f"Error writing GeoIP DB file: {db_archive_path} - {err}"
                 )
         finally:
             if db_archive_path.is_file():
                 self._pr_debug(f"Removing temp file {db_archive_path}")
                 db_archive_path.unlink()
-            if warn_messages:
-                self._geolite_warn(warn_messages)
         return False
 
     # pylint: enable=too-many-branches
 
-    def _extract_to_folder(self, db_archive_path, db_folder):
+    def _extract_to_folder(self, db_archive_path):
         self._pr_debug(f"Extracting tarfile {db_archive_path}")
+        temp_folder: Optional[Path] = None
         with tarfile.open(db_archive_path) as tar_archive:
             for member in tar_archive.getmembers():
                 if not member.isreg():
+                    # Skip the dirs to extract only file objects
                     continue
-                # Will skip the dirs to extract only file objects
-                self._pr_debug(f"extracting {member} to {db_folder}")
-                tar_archive.extract(member, db_folder)
-                # The files are extract to a subfolder (with a date in the name)
+                self._pr_debug(f"extracting {member} to {self._db_folder}")
+                tar_archive.extract(member, self._db_folder)
+                # The files are extracted to a subfolder (with a date in the name)
                 # We want to move these into the main folder above this.
                 targetname = Path(member.name).name
                 if targetname != member.name:
-                    curr_file = Path(db_folder).joinpath(member.name)
-                    extr_folder = Path(db_folder).joinpath(member.name).parent
-                    curr_file.replace(Path(db_folder).joinpath(targetname))
-                    self._pr_debug(f"Moving to {Path(db_folder).joinpath(targetname)}")
-                    # if the folder is empty, remove it
-                    if not list(extr_folder.glob("*")):
-                        extr_folder.rmdir()
+                    # if target name is not already in self._dbfolder
+                    # move it to there
+                    target_file_path = Path(self._db_folder).joinpath(member.name)
+                    temp_folder = target_file_path.parent
+                    target_file_path.replace(Path(self._db_folder).joinpath(targetname))
+                    self._pr_debug(
+                        f"Moving to {Path(self._db_folder).joinpath(targetname)}"
+                    )
+        # delete contents of temp folder and remove it
+        if temp_folder:
+            for temp_file in temp_folder.glob("*"):
+                temp_file.unlink()
+            self._pr_debug(f"Removing temp path {temp_folder}")
+            temp_folder.rmdir()
 
-    @staticmethod
-    def _get_geoip_dbpath(db_folder: str = None) -> Optional[str]:
-        r"""
+    def _get_geoip_db_path(self) -> Optional[str]:
+        """
         Get the correct path containing GeoLite City Database.
-
-        Parameters
-        ----------
-        db_folder: str, optional
-            Provide absolute path to the folder containing MMDB file
-            (e.g. '/usr/home' or 'C:\maxmind').
-            If no path provided, it is set to download to .msticpy\GeoLite2 dir under
-            user`s home directory.
 
         Returns
         -------
@@ -836,18 +734,67 @@ Alternatively, you can pass this to the GeoLiteLookup class when creating it:
             database after control flow logic.
 
         """
-        if not db_folder:
-            db_folder = "."
-        list_of_db_paths = [str(db) for db in Path(db_folder).glob("*.mmdb")]
+        latest_db_path = Path(self._db_folder or ".").joinpath(self._DB_FILE)
+        return str(latest_db_path) if latest_db_path.is_file() else None
 
-        if len(list_of_db_paths) > 1:
-            latest_db_path = max(list_of_db_paths, key=os.path.getmtime)
-        elif len(list_of_db_paths) == 1:
-            latest_db_path = list_of_db_paths[0]
-        else:
-            return None
+    def _pr_debug(self, *args):
+        """Print out debug info."""
+        if self._debug:
+            print(*args)
 
-        return latest_db_path
+    def _geolite_warn(self, mssg):
+        self._pr_debug(mssg)
+        warnings.warn(
+            f"GeoIpLookup: {mssg}",
+            UserWarning,
+        )
+
+    def _raise_no_db_error(self):
+        raise MsticpyUserConfigError(
+            "No usable GeoIP Database could be found.",
+            (
+                "Check that you have correctly configured the Maxmind API key in "
+                "msticpyconfig.yaml."
+            ),
+            (
+                "If you are using a custom DBFolder setting in your config, "
+                + f"check that this is a valid path: {self._db_folder}."
+            ),
+            (
+                "If you edit your msticpyconfig to change this setting run the "
+                "following commands to reload your settings and retry:"
+                "    import msticpy"
+                "    msticpy.settings.refresh_config()"
+            ),
+            help_uri=(
+                "https://msticpy.readthedocs.io/en/latest/data_acquisition/"
+                + "GeoIPLookups.html#maxmind-geo-ip-lite-lookup-class"
+            ),
+            service_uri="https://www.maxmind.com/en/geolite2/signup",
+            title="Maxmind GeoIP database not found",
+        )
+
+    def _debug_open_state(self):
+        dbg_api_key = (
+            "None"
+            if self._api_key is None
+            else self._api_key[:4] + "*" * (len(self._api_key) - 4)
+        )
+        self._pr_debug(f"__init__ values (inc settings): api_key={dbg_api_key}")
+        self._pr_debug(f"    db_folder={self._db_folder}")
+        self._pr_debug(f"    force_update={self._force_update}")
+        self._pr_debug(f"    auto_update={self._auto_update}")
+        self._pr_debug(f"    dbpath={self._db_path}")
+        self._pr_debug(f"Using config file: {current_config_path()}")
+
+    def _debug_init_state(self, api_key, db_folder, force_update, auto_update):
+        dbg_api_key = (
+            "None" if api_key is None else api_key[:4] + "*" * (len(api_key) - 4)
+        )
+        self._pr_debug(f"__init__ params: api_key={dbg_api_key}")
+        self._pr_debug(f"    db_folder={db_folder}")
+        self._pr_debug(f"    force_update={force_update}")
+        self._pr_debug(f"    auto_update={auto_update}")
 
 
 def _get_geoip_provider_settings(provider_name: str) -> ProviderSettings:

--- a/msticpy/data/drivers/driver_base.py
+++ b/msticpy/data/drivers/driver_base.py
@@ -12,9 +12,9 @@ from typing import Any, Callable, Dict, Iterable, Optional, Set, Tuple, Union
 import pandas as pd
 
 from ..._version import VERSION
-from ..core.query_source import QuerySource
 from ...common.exceptions import MsticpyNotConnectedError
-from ...common.provider_settings import get_provider_settings, ProviderSettings
+from ...common.provider_settings import ProviderSettings, get_provider_settings
+from ..core.query_source import QuerySource
 
 __version__ = VERSION
 __author__ = "Ian Hellen"

--- a/msticpy/data/drivers/kusto_driver.py
+++ b/msticpy/data/drivers/kusto_driver.py
@@ -149,12 +149,12 @@ class KustoDriver(KqlDriver):
     def _get_connection_string(self, query_source: QuerySource = None, **kwargs):
         """Create a connection string from arguments and configuration."""
         # If the connection string is supplied as a parameter, use that
-        cluster = database = None
+        cluster = None
         new_connection = kwargs.get("connection_str")
+        database = kwargs.get("database")
         if not new_connection:
             # try to get cluster and db from kwargs or query_source metadata
-            cluster = self._lookup_cluster(kwargs.get("cluster", ""))
-            database = kwargs.get("database")
+            cluster = self._lookup_cluster(kwargs.get("cluster", "Kusto"))
             if cluster and database:
                 new_connection = self._create_connection(
                     cluster=cluster, database=database
@@ -163,21 +163,28 @@ class KustoDriver(KqlDriver):
         if not new_connection and query_source:
             # try to get cluster and db from query_source metadata
             cluster = cluster or query_source.metadata.get("cluster")
-            data_families = query_source.metadata.get("data_families")
-            if (
-                not isinstance(data_families, list) or len(data_families) == 0
-            ) and not self.current_connection:
-                # call create connection so that we throw an informative error
-                self._create_connection(cluster=cluster, database=database)
-            if "." in data_families[0]:  # type: ignore
-                _, qry_db = data_families[0].split(".", maxsplit=1)  # type: ignore
-            else:
-                # Not expected but we can still use a DB value with no dot
-                qry_db = data_families[0]  # type: ignore
-            database = database or qry_db
+            database = (
+                database
+                or query_source.metadata.get("database")
+                or self._get_db_from_datafamily(query_source, cluster, database)
+            )
             new_connection = self._create_connection(cluster=cluster, database=database)
             self._cluster_uri = cluster
         return new_connection
+
+    def _get_db_from_datafamily(self, query_source, cluster, database):
+        data_families = query_source.metadata.get("data_families")
+        if (
+            not isinstance(data_families, list) or len(data_families) == 0
+        ) and not self.current_connection:
+            # call create connection so that we throw an informative error
+            self._create_connection(cluster=cluster, database=database)
+        if "." in data_families[0]:  # type: ignore
+            _, qry_db = data_families[0].split(".", maxsplit=1)  # type: ignore
+        else:
+            # Not expected but we can still use a DB value with no dot
+            qry_db = data_families[0]  # type: ignore
+        return qry_db
 
     def _create_connection(self, cluster, database):
         """Create the connection string, checking parameters."""
@@ -244,7 +251,13 @@ class KustoDriver(KqlDriver):
             (
                 kusto_config["cluster"]
                 for cluster_key, kusto_config in self._kusto_settings.items()
-                if cluster_key.startswith(f"https://{cluster.casefold()}.")
+                if (
+                    cluster_key.startswith(f"https://{cluster.casefold()}.")
+                    or (
+                        kusto_config.get("alias", "").casefold()  # type: ignore
+                        == cluster.casefold()
+                    )
+                )
             ),
             None,
         )

--- a/tests/common/test_pkg_config.py
+++ b/tests/common/test_pkg_config.py
@@ -107,7 +107,7 @@ class TestPkgConfig(unittest.TestCase):
             self.assertIsInstance(geoip_lite._api_key, str)
             self.assertEqual(geoip_lite._api_key, os.environ["MAXMIND_AUTH"])
 
-            self.assertEqual(geoip_lite._dbfolder, conf_dbpath)
+            self.assertEqual(geoip_lite._db_folder, conf_dbpath)
 
             ipstack = IPStackLookup()
             self.assertEqual(ipstack._api_key, "987654321-222")

--- a/tests/config/test_mp_config.py
+++ b/tests/config/test_mp_config.py
@@ -25,10 +25,11 @@ CompEditStatusMixin.testing = True
 def test_mp_config_file_init():
     """Test MpConfigFile init."""
     mpc_file = MpConfigFile()
-    check.is_false(mpc_file.settings)
+    check.is_true(mpc_file.settings)
 
     # Test loading with empty settings
     mpc_file = MpConfigFile(settings={})
+    check.is_false(mpc_file.settings)
 
     mpc_file = MpConfigFile()
     # load file
@@ -37,6 +38,7 @@ def test_mp_config_file_init():
 
     config_path = Path(TEST_DATA_PATH).joinpath("msticpyconfig.yaml")
     mpc_file = MpConfigFile(file=config_path)
+    check.is_true(mpc_file.settings)
 
 
 def test_mp_config_file_load_default():
@@ -63,7 +65,7 @@ def test_mp_config_file_view_settings():
     mpc_file = MpConfigFile()
     mpc_file.txt_viewer.value = ""
     mpc_file.view_settings()
-    check.is_true(len(mpc_file.txt_viewer.value) > 0)
+    check.greater(len(mpc_file.txt_viewer.value), 0)
     mpc_file.buttons["view"].click()
     mpc_file.btn_close.click()
 

--- a/tests/config/test_mp_config_edit.py
+++ b/tests/config/test_mp_config_edit.py
@@ -140,5 +140,6 @@ def test_mp_edit_load_params():
     # Test no existing MPConfig
     with custom_mp_config(str(config_path)):
         os.environ["MSTICPYCONFIG"] = "./invalid_file.yaml"
-        mp_conf = MpConfigEdit()
-        check.equal(mp_conf.mp_conf_file.settings, {})
+        with pytest.raises(ValueError):
+            with pytest.warns(UserWarning):
+                mp_conf = MpConfigEdit()

--- a/tests/sectools/test_geoip.py
+++ b/tests/sectools/test_geoip.py
@@ -77,6 +77,8 @@ def test_geoiplite_download(tmp_path):
                 ip_location = GeoLiteLookup(
                     db_folder=str(tgt_folder), force_update=True, debug=True
                 )
+                ip_location._check_db_open()
+                check.is_true(tgt_folder.joinpath("GeoLite2-City.mmdb").is_file())
                 ip_location.close()
         if warning_record:
             print(f"{len(warning_record)} warnings recorded")


### PR DESCRIPTION

Some fixes to Kusto common_imports

- now works with Kusto config entry without instance suffix
- can now supply cluster ALIAS (instance name) instead of actual cluster name in connect or query
- added explicit "database" key in query files - can be used instead of the more opaque "data_family.database" encoding
  in the data_famiies key.
Fixed documentation in DataProv-Kusto.rst to correct inaccuracies and update sections on query templates and configuration

Fixed bug and simplified/cleaned up code for GeoLiteLookup in geoip.py.

Fixed bug in mp_config_edit.py and mp_config_file.py where empty/new msticpyconfig.yaml didn't save any settings.
Reorganized logic for handling parameters and failing on invalid file path in config module.