### PR TITLE
Add Device Code fallback option for when interactive auth isn't avaliable.

### DIFF
--- a/msticpy/auth/azure_auth_core.py
+++ b/msticpy/auth/azure_auth_core.py
@@ -37,16 +37,6 @@ __author__ = "Pete Bryan"
 
 AzCredentials = namedtuple("AzCredentials", ["legacy", "modern"])
 
-_EXCLUDED_AUTH = {
-    "cli": True,
-    "env": True,
-    "msi": True,
-    "vscode": True,
-    "powershell": True,
-    "interactive": True,
-    "cache": True,
-}
-
 
 def get_azure_config_value(key, default):
     """Get a config value from Azure section."""
@@ -208,19 +198,28 @@ def _az_connect_core(
     az_config = AzureCloudConfig(cloud)
     aad_uri = az_config.endpoints.active_directory
     tenant_id = tenant_id or AzureCloudConfig().tenant_id
+    excluded_auth = {
+        "cli": True,
+        "env": True,
+        "msi": True,
+        "vscode": True,
+        "powershell": True,
+        "interactive": True,
+        "cache": True,
+    }
     if auth_methods:
         for method in auth_methods:
-            if method in _EXCLUDED_AUTH:
-                _EXCLUDED_AUTH[method] = False
+            if method in excluded_auth:
+                excluded_auth[method] = False
         creds = DefaultAzureCredential(
             authority=aad_uri,
-            exclude_cli_credential=_EXCLUDED_AUTH["cli"],
-            exclude_environment_credential=_EXCLUDED_AUTH["env"],
-            exclude_managed_identity_credential=_EXCLUDED_AUTH["msi"],
-            exclude_powershell_credential=_EXCLUDED_AUTH["powershell"],
-            exclude_visual_studio_code_credential=_EXCLUDED_AUTH["vscode"],
-            exclude_shared_token_cache_credential=_EXCLUDED_AUTH["cache"],
-            exclude_interactive_browser_credential=_EXCLUDED_AUTH["interactive"],
+            exclude_cli_credential=excluded_auth["cli"],
+            exclude_environment_credential=excluded_auth["env"],
+            exclude_managed_identity_credential=excluded_auth["msi"],
+            exclude_powershell_credential=excluded_auth["powershell"],
+            exclude_visual_studio_code_credential=excluded_auth["vscode"],
+            exclude_shared_token_cache_credential=excluded_auth["cache"],
+            exclude_interactive_browser_credential=excluded_auth["interactive"],
             interactive_browser_tenant_id=tenant_id,
         )
     else:

--- a/msticpy/context/azure/sentinel_analytics.py
+++ b/msticpy/context/azure/sentinel_analytics.py
@@ -56,7 +56,9 @@ class SentinelAnalyticsMixin:
             A table of the workspace's alert rules.
 
         """
-        return self._list_items(item_type="alert_rules")  # type: ignore
+        return self._list_items(  # type: ignore
+            item_type="alert_rules", api_version="2021-10-01"
+        )
 
     def _get_template_id(
         self,

--- a/msticpy/context/azure/sentinel_core.py
+++ b/msticpy/context/azure/sentinel_core.py
@@ -65,7 +65,8 @@ class MicrosoftSentinel(
             Sentinel Workspace, by default None
 
         """
-        super().__init__(connect=connect, cloud=cloud)
+        self.user_cloud = cloud
+        super().__init__(connect=connect, cloud=self.user_cloud)
         self.config = None  # type: ignore
         self.base_url = self.endpoints.resource_manager
         self.default_subscription: Optional[str] = None
@@ -110,7 +111,9 @@ class MicrosoftSentinel(
         if "token" in kwargs:
             self.token = kwargs["token"]
         else:
-            self.token = get_token(self.credentials)  # type: ignore
+            self.token = get_token(
+                self.credentials, tenant_id=tenant_id, cloud=self.user_cloud
+            )  # type: ignore
 
         self.res_group_url = None
         self.prov_path = None


### PR DESCRIPTION
The current fallback authentication option for Azure Auth is the interactive login. However this requires a browser to be present - which means it doesn't work for AML. 

To tackle this I've added a fall-back option to use Device Code authentication in the situation where all other auth methods fail.

This is achieved by:
  - Adding a function to azure_auth that get credentials from device code.
  - Updated KQL driver and AzureSentinel to use this fallback of needed (in the case of KQL driver it falls back to KQL magics inbuilt device code auth.

This PR doesn't address authentication in Azure Data features as they use the Azure SDK to handle this auth. More work is required in this area.