### PR TITLE
Replace MSAL auth plaintext file cache with memory cache

### DIFF
--- a/msticpy/common/msal_auth.py
+++ b/msticpy/common/msal_auth.py
@@ -62,7 +62,8 @@ class MSALDelegatedAuth:
         self.scopes = scopes
         self.result = None
 
-        if persistence := self._create_cache():
+        persistence = self._create_cache()
+        if persistence:
             self.token_cache = PersistedTokenCache(persistence)
 
         self.app = msal.PublicClientApplication(
@@ -77,7 +78,8 @@ class MSALDelegatedAuth:
 
     def get_token(self):
         """Get an authneticaiton token."""
-        if chosen_account := self.app.get_accounts(username=self.username):
+        chosen_account = self.app.get_accounts(username=self.username)
+        if chosen_account:
             self.result = self.app.acquire_token_silent_with_error(
                 scopes=self.scopes, account=chosen_account[0]
             )
@@ -90,7 +92,8 @@ class MSALDelegatedAuth:
     def refresh_token(self):
         """Refresh the authentication token."""
         self.result = None
-        if chosen_account := self.app.get_accounts(username=self.username):
+        chosen_account = self.app.get_accounts(username=self.username)
+        if chosen_account:
             self.result = self.app.acquire_token_silent_with_error(
                 scopes=self.scopes, account=chosen_account[0], force_refresh=True
             )

--- a/msticpy/common/msal_auth.py
+++ b/msticpy/common/msal_auth.py
@@ -126,7 +126,7 @@ class MSALDelegatedAuth:
                         "msal_token2": "msal_token_values",
                     },
                 )
-            except (PersistenceNotFound, ImportError):
+            except (PersistenceNotFound, ImportError, ValueError):
                 print("Unable to create encrypted token cache - using in memory cache.")
                 return None
 

--- a/msticpy/data/drivers/odata_driver.py
+++ b/msticpy/data/drivers/odata_driver.py
@@ -189,7 +189,6 @@ class OData(DriverBase):
                 if "location" in cs_dict
                 else "token_cache.bin",
                 connect=True,
-                plaintext=kwargs["plaintext"] if "plaintext" in kwargs else "False",
             )
             self.aad_token = self.msal_auth.token
             json_response = {}

--- a/tests/common/test_msal_auth.py
+++ b/tests/common/test_msal_auth.py
@@ -52,7 +52,6 @@ def test_msal_auth_device(msal_mock):
         username="test@test.com",
         scopes=["User.Read"],
         auth_type="device",
-        plaintext=True,
     )
     auth.get_token()
     assert auth.token == "aHR0cHM6Ly9yZWFkdGhlZG9jcy5vcmcvcHJvamVjdHMvbXN0aWNweS8="
@@ -67,7 +66,6 @@ def test_msal_auth(msal_mock):
         authority="https://login.microsoftonline.com",
         username="test@test.com",
         scopes=["User.Read"],
-        plaintext=True,
     )
     auth.get_token()
     assert auth.token == "aHR0cHM6Ly9yZWFkdGhlZG9jcy5vcmcvcHJvamVjdHMvbXN0aWNweS8="
@@ -82,7 +80,6 @@ def test_msal_auth_unkown_user(msal_mock):
         authority="https://login.microsoftonline.com",
         username="test@test2.com",
         scopes=["User.Read"],
-        plaintext=True,
     )
     auth.get_token()
     assert auth.token == "aHR0cHM6Ly9yZWFkdGhlZG9jcy5vcmcvcHJvamVjdHMvbXN0aWNweS8="


### PR DESCRIPTION
Replaced the plain text token cache fallback in msal_auth with a in memory cache.