### PR TITLE
[fix] Sentinel TI provider causing Pivot infinite recursion 

### DIFF
--- a/docs/source/getting_started/msticpyconfig.rst
+++ b/docs/source/getting_started/msticpyconfig.rst
@@ -566,7 +566,6 @@ of other data providers and components.
           query_provider:
             AzureSentinel:
               workspace: CyberSoc
-        Pivot:
         AzureData:
           auth_methods=['cli','interactive']
         AzureSentinelAPI:
@@ -603,9 +602,6 @@ providers (query and others such as TILookip) as its ``providers`` parameter.
 For more details see
 `data_providers.init <https://msticnb.readthedocs.io/en/latest/msticnb.html#msticnb.data_providers.init>`__.
 
-``Pivot`` loads the Pivot library to add pivot functions to *MSTICPy* entities.
-It requires other providers to be loaded before itself (in order to
-harvest the pivot functions from them) so it is loaded last.
 
 ``AzureData`` and ``AzureSentinel`` load the Azure resource API and Azure
 Sentinel API libraries respectively. Any key/pair values defined under either
@@ -626,7 +622,6 @@ configuration settings:
 - geoip
 - ti_lookup
 - nb
-- pivot
 - az_data
 - azs_api
 
@@ -650,7 +645,6 @@ provider instances created are also stored in an attribute of the
     'qry_local': <msticpy.data.data_providers.QueryProvider at 0x216605a7c48>,
     'ti_lookup': <msticpy.context.tilookup.TILookup at 0x216611c7908>,
     'geoip': <msticpy.context.geoip.GeoLiteLookup at 0x21660659c88>,
-    'pivot': <msticpy.datamodel.pivot.Pivot at 0x216602d8e88>,
     'az_data': <msticpy.context.azure_data.AzureData at 0x21668aaf708>,
     'azs_api': <msticpy.context.azure_sentinel.AzureSentinel at 0x21603f42388>,
     'nb': <module 'msticnb' from 'e:\\src\\msticnb\\msticnb\\__init__.py'>}

--- a/msticpy/context/tiproviders/kql_base.py
+++ b/msticpy/context/tiproviders/kql_base.py
@@ -345,6 +345,7 @@ class KqlTIProvider(TIProvider):
 
     def _connect(self):
         """Connect to query provider."""
+        print("MS Sentinel TI query provider needs authenticated connection.")
         self._query_provider.connect(self._connect_str)
 
     @staticmethod

--- a/msticpy/context/tiproviders/kql_base.py
+++ b/msticpy/context/tiproviders/kql_base.py
@@ -57,11 +57,18 @@ class KqlTIProvider(TIProvider):
             kwargs["query_provider"], QueryProvider
         ):
             self._query_provider = kwargs.pop("query_provider")
+            self._connect_str = kwargs.pop("connect_str", WorkspaceConfig())
         else:
-            self._query_provider = self._create_query_provider(**kwargs)
+            self._query_provider, self._connect_str = self._create_query_provider(
+                **kwargs
+            )
 
-        if not self._query_provider or not self._query_provider.connected:
+        if not self._query_provider:
             raise MsticpyConfigException("Query provider for KQL could not be created.")
+
+    @property
+    def _connected(self):
+        return self._query_provider.connected
 
     @lru_cache(maxsize=256)
     def lookup_ioc(  # type: ignore
@@ -102,6 +109,9 @@ class KqlTIProvider(TIProvider):
         the same item.
 
         """
+        if not self._connected:
+            self._connect()
+
         # check and lookup (if needed) ioc_type
         result = self._check_ioc_type(
             ioc=ioc, ioc_type=ioc_type, query_subtype=query_type
@@ -173,6 +183,8 @@ class KqlTIProvider(TIProvider):
             DataFrame of results.
 
         """
+        if not self._connected:
+            self._connect()
         # We need to partition the IoC types to invoke separate queries
         ioc_groups: DefaultDict[str, Set[str]] = defaultdict(set)
         for ioc, ioc_type in generate_items(data, obs_col, ioc_type_col):
@@ -329,8 +341,11 @@ class KqlTIProvider(TIProvider):
             TENANT_ID=tenant_id, WORKSPACE_ID=workspace_id
         )
         query_provider = QueryProvider("LogAnalytics")
-        query_provider.connect(connect_str)
-        return query_provider
+        return query_provider, connect_str
+
+    def _connect(self):
+        """Connect to query provider."""
+        self._query_provider.connect(self._connect_str)
 
     @staticmethod
     def _get_spelled_variants(name: str, **kwargs) -> Any:

--- a/msticpy/data/drivers/kql_driver.py
+++ b/msticpy/data/drivers/kql_driver.py
@@ -57,6 +57,8 @@ _KQL_CLOUD_MAP = {
     "de": "germany",
 }
 
+_KQL_OPTIONS = ["timeout"]
+
 _AZ_CLOUD_MAP = {kql_cloud: az_cloud for az_cloud, kql_cloud in _KQL_CLOUD_MAP.items()}
 
 _LOGANALYTICS_URL_BY_CLOUD = {
@@ -238,7 +240,7 @@ class KqlDriver(DriverBase):
         Returns
         -------
         Union[pd.DataFrame, results.ResultSet]
-            A DataFrame (if successfull) or
+            A DataFrame (if successful) or
             the underlying provider result if an error.
 
         """
@@ -297,7 +299,13 @@ class KqlDriver(DriverBase):
         if not query.strip().endswith(";"):
             query = f"{query}\n;"
 
-        result = kql_exec(query, options=kwargs)
+        # Add any Kqlmagic options from kwargs
+        kql_opts = {
+            option: option_val
+            for option, option_val in kwargs.items()
+            if option in _KQL_OPTIONS
+        }
+        result = kql_exec(query, options=kql_opts)
         self._set_kql_option(option="auto_dataframe", value=auto_dataframe)
         if result is not None:
             if isinstance(result, pd.DataFrame):

--- a/msticpy/init/nbinit.py
+++ b/msticpy/init/nbinit.py
@@ -592,6 +592,7 @@ def _load_pivots(namespace):
     # pylint: disable=no-member
     if not Pivot.current():
         pivot = Pivot()
+        pivot.reload_pivots()
         namespace["pivot"] = pivot
         # pylint: disable=import-outside-toplevel, cyclic-import
         import msticpy

--- a/msticpy/init/user_config.py
+++ b/msticpy/init/user_config.py
@@ -223,17 +223,6 @@ def _load_notebooklets(comp_settings=None, **kwargs):
     return None, None
 
 
-def _load_pivot(comp_settings=None, **kwargs):
-    del comp_settings
-    from .pivot import Pivot
-
-    namespace = kwargs.get("global_ns", {}).copy()
-    namespace.update(kwargs.get("local_ns", {}))
-    piv_kwargs = {"namespace": namespace}
-    pivot = Pivot(**piv_kwargs)
-    return "pivot", pivot
-
-
 def _load_azure_data(comp_settings=None, **kwargs):
     del kwargs
     from ..context.azure.azure_data import AzureData
@@ -272,7 +261,6 @@ COMP_LOADERS = {
     "GeoIpLookup": _load_geoip_lookup,
     "AzureData": _load_azure_data,
     "AzureSentinelAPI": _load_azsent_api,
-    "Pivot": _load_pivot,  # Pivots loaded after most providers
     "Notebooklets": _load_notebooklets,  # Notebooklets calls add_pivots
 }
 
@@ -284,6 +272,6 @@ def _get_provider_names(prov_dict):
             providers.append(obj.environment.casefold())
         else:
             cls_name = obj.__class__.__name__
-            if cls_name in COMP_LOADERS and cls_name != "Pivot":
+            if cls_name in COMP_LOADERS:
                 providers.append(cls_name.casefold())
     return providers

--- a/tests/datamodel/entities/test_entity.py
+++ b/tests/datamodel/entities/test_entity.py
@@ -77,7 +77,8 @@ def test_url():
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_pivot_shortcuts():
     """Test pivot function shortcut creation and deletion."""
-    Pivot()
+    pivot = Pivot()
+    pivot.reload_pivots()
 
     check.is_true(hasattr(IpAddress, "util"))
     util_ctnr = getattr(IpAddress, "util")

--- a/tests/init/test_user_config.py
+++ b/tests/init/test_user_config.py
@@ -60,7 +60,6 @@ UserDefaults:
         LocalData:
           workspace: CyberSoc
           some_param: some_value
-    Pivot:
     AzureData:
       auth_methods: ['cli','interactive']
       connect: False
@@ -81,10 +80,6 @@ def mp_settings():
         "LoadComponents", {}
     ).get("Notebooklets"):
         del settings_dict["UserDefaults"]["LoadComponents"]["Notebooklets"]
-    if not _PIVOT and settings_dict["UserDefaults"].get("LoadComponents", {}).get(
-        "Pivot"
-    ):
-        del settings_dict["UserDefaults"]["LoadComponents"]["Pivot"]
     return settings_dict
 
 

--- a/tests/msticpyconfig-test.yaml
+++ b/tests/msticpyconfig-test.yaml
@@ -60,6 +60,10 @@ TIProviders:
         EnvironmentVar: "INTSIGHTS_AUTH"
     Primary: True
     Provider: IntSights
+  AzureSentinel:
+    Args:
+    Primary: True
+    Provider: "AzSTI"
 OtherProviders:
   GeoIPLite:
     Args:


### PR DESCRIPTION
- separated pivot function loading from __init__ in pivot.py. reload_pivots also
  has an alias "load_pivots"
- added call to reload_pivots in nbinit.py
- stopped AzSTI (kql_base child classes) from trying to connect on loading)
  this allows it to be used in tests more easily
- removed _get_query_providers from pivot.py - since query providers handle their
  own pivot functions this is duplicative and not needed
- removed pivot entry from user_config.py - since pivot is always initialized in nbinit
- fixed test_entity unit test - needed to add call to reload_pivots in test
- removed pivot items from test_user_config.py
- updated msticpyconfig.rst to remove references to pivot in user config sections.