### PR TITLE
Azure ML init fix

### DIFF
--- a/msticpy/common/pkg_config.py
+++ b/msticpy/common/pkg_config.py
@@ -40,7 +40,7 @@ _CONFIG_ENV_VAR: str = "MSTICPYCONFIG"
 _DP_KEY = "DataProviders"
 _AZ_SENTINEL = "AzureSentinel"
 _AZ_CLI = "AzureCLI"
-_HOME_PATH = f"~/.msticpy/{_CONFIG_FILE}"
+_HOME_PATH = "~/.msticpy/"
 
 # pylint: disable=invalid-name
 default_settings: Dict[str, Any] = {}
@@ -245,7 +245,7 @@ def _get_custom_config():
         _CURRENT_CONF_FILE(str(Path(".").joinpath(_CONFIG_FILE).resolve()))
         return _read_config_file(current_config_path())
 
-    home_config = Path(_HOME_PATH).expanduser().resolve()
+    home_config = Path(os.path.join(_HOME_PATH, _CONFIG_FILE)).expanduser().resolve()
     if home_config.is_file():
         _CURRENT_CONF_FILE(str(home_config))
         return _read_config_file(current_config_path())

--- a/msticpy/common/utility/package.py
+++ b/msticpy/common/utility/package.py
@@ -195,7 +195,7 @@ def search_for_file(
     """Search `paths` for file `pattern`."""
     paths = paths or [".", ".."]
     for start_path in paths:
-        found_files = list(Path(start_path).glob(pattern))
+        found_files = list(Path(start_path).glob(pattern)) if start_path else []
         if found_files:
             return str(found_files[0])
     return None

--- a/msticpy/init/nbinit.py
+++ b/msticpy/init/nbinit.py
@@ -31,7 +31,7 @@ from .._version import VERSION
 from ..auth.azure_auth_core import AzureCliStatus, check_cli_credentials
 from ..common.check_version import check_version
 from ..common.exceptions import MsticpyException, MsticpyUserError
-from ..common.pkg_config import get_config, refresh_config, validate_config
+from ..common.pkg_config import get_config, refresh_config, validate_config, _HOME_PATH
 from ..common.utility import (
     check_and_install_missing_packages,
     check_kwargs,
@@ -533,7 +533,7 @@ def _get_or_create_config() -> bool:
     if mp_path and not Path(mp_path).is_file():
         _err_output(_MISSING_MPCONFIG_ENV_ERR)
     if not mp_path or not Path(mp_path).is_file():
-        mp_path = search_for_file("msticpyconfig.yaml", paths=["."])
+        mp_path = search_for_file("msticpyconfig.yaml", paths=[".", _HOME_PATH])
 
     if mp_path:
         errs: List[str] = []


### PR DESCRIPTION
Function _get_aml_user_folder()_ can return None which is not properly handled by the code. As the (default) $HOME is set on Azure ML to "/home/azureuser", searching for the string "User" will not work.

Furthermore, the code and the documentation references multiple time the home folder with ~ to find the msticpyconfig.yaml file:
https://docs.microsoft.com/en-us/azure/sentinel/notebooks-msticpy-advanced?tabs=azure-ml
we can probably store the other configuration files in the same place?