### PR TITLE
[update] DNS resolver return dataframe with one IP per row

### DIFF
--- a/msticpy/context/domain_utils.py
+++ b/msticpy/context/domain_utils.py
@@ -306,6 +306,31 @@ def dns_resolve(url_domain: str, rec_type: str = "A") -> Dict[str, Any]:
 
 
 @export
+def dns_resolve_df(url_domain: str, rec_type: str = "A") -> pd.DataFrame:
+    """
+    Validate if a domain or URL be be resolved to an IP address.
+
+    Parameters
+    ----------
+    url_domain : str
+        The url or domain to validate.
+    rec_type : str
+        The DNS record type to query, by default "A"
+
+    Returns
+    -------
+    pd.DataFrame:
+        Resolver result as dataframe with individual resolution
+        results as separate rows.
+
+    """
+    results = pd.DataFrame([dns_resolve(url_domain, rec_type)])
+    if "rrset" in results.columns:
+        return results.explode(column="rrset")
+    return results
+
+
+@export
 def ip_rev_resolve(ip_address: str) -> Dict[str, Any]:
     """
     Reverse lookup for IP Address.
@@ -329,6 +354,29 @@ def ip_rev_resolve(ip_address: str) -> Dict[str, Any]:
             "rdtype": "PTR",
             "response": str(err),
         }
+
+
+@export
+def ip_rev_resolve_df(ip_address: str) -> pd.DataFrame:
+    """
+    Reverse lookup for IP Address.
+
+    Parameters
+    ----------
+    ip_address : str
+        The IP address to query.
+
+    Returns
+    -------
+    pd.DataFrame:
+        Resolver result as dataframe with individual resolution
+        results as separate rows.
+
+    """
+    results = pd.DataFrame([ip_rev_resolve(ip_address)])
+    if "rrset" in results.columns:
+        return results.explode(column="rrset")
+    return results
 
 
 @export

--- a/msticpy/resources/mp_pivot_reg.yaml
+++ b/msticpy/resources/mp_pivot_reg.yaml
@@ -185,7 +185,8 @@ pivot_providers:
     func_input_value_arg: url
   dns_resolve:
     src_module: msticpy.context.domain_utils
-    src_func_name: dns_resolve
+    src_func_name: dns_resolve_df
+    func_new_name: dns_resolve
     input_type: value
     can_iterate: True
     entity_map:
@@ -196,7 +197,8 @@ pivot_providers:
     create_shortcut: True
   ip_rev_resolve:
     src_module: msticpy.context.domain_utils
-    src_func_name: ip_rev_resolve
+    src_func_name: ip_rev_resolve_df
+    func_new_name: ip_rev_resolve
     input_type: value
     can_iterate: True
     entity_map:

--- a/tests/context/test_domain_utils.py
+++ b/tests/context/test_domain_utils.py
@@ -3,7 +3,10 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-"""domain_utilstes extract test class."""
+"""domain_utilities extract test class."""
+import ipaddress
+
+import pandas as pd
 import pytest_check as check
 
 from msticpy.context import domain_utils
@@ -42,6 +45,17 @@ def test_resolver_funcs():
 
     result = domain_utils.ip_rev_resolve(ip)
     check.is_not_none(result)
+
+    result_df = domain_utils.dns_resolve_df("www.microsoft.com")
+    check.is_instance(result_df, pd.DataFrame)
+    check.greater_equal(len(result_df), 1)
+    ip = result_df.iloc[0].rrset
+    ip_addr = ipaddress.ip_address(ip)
+    check.is_instance(ip_addr, (ipaddress.IPv4Address, ipaddress.IPv6Address))
+
+    result_df = domain_utils.ip_rev_resolve_df(ip)
+    check.is_instance(result_df, pd.DataFrame)
+    check.greater_equal(len(result_df), 1)
 
     result = domain_utils.dns_components("www.microsoft.com")
     check.equal(result["subdomain"], "www")


### PR DESCRIPTION
Added wrapper functions to split DNS query responses into one item per row. domain_utils.py