### PR TITLE
[fix] Updated SQL to KQL converter to use mo_sql_parsing

### DIFF
--- a/conda/conda-reqs-dev-pip.txt
+++ b/conda/conda-reqs-dev-pip.txt
@@ -1,3 +1,4 @@
 
+async-cache>=1.1.1
 pyroma>=3.1
 pytest-check>=1.0.1

--- a/conda/conda-reqs-pip.txt
+++ b/conda/conda-reqs-pip.txt
@@ -2,6 +2,6 @@ azure-mgmt-monitor>=2.0.0
 azure-mgmt-resourcegraph>=8.0.0
 azure-mgmt-subscription>=1.0.0
 KqlmagicCustom[jupyter-basic,auth_code_clipboard]>=0.1.114
-moz_sql_parser>=4.5.0,<=4.11.21016
+mo-sql-parsing>=8
 passivetotal>=2.5.3
 splunk-sdk>=1.6.0

--- a/docs/source/DataAcquisition.rst
+++ b/docs/source/DataAcquisition.rst
@@ -47,7 +47,6 @@ Other Data Modules and Functions
    data_acquisition/DataMasking
    data_acquisition/AzureBlobStorage
    data_acquisition/SqlToKql
-   data_acquisition/CybereasonProvider
 
 Contributing a Data Provider
 ----------------------------

--- a/docs/source/api/msticpy.common.azure_auth.rst
+++ b/docs/source/api/msticpy.common.azure_auth.rst
@@ -1,0 +1,7 @@
+msticpy.common.azure\_auth module
+=================================
+
+.. automodule:: msticpy.common.azure_auth
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/msticpy.common.rst
+++ b/docs/source/api/msticpy.common.rst
@@ -20,6 +20,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   msticpy.common.azure_auth
    msticpy.common.check_version
    msticpy.common.data_types
    msticpy.common.data_utils

--- a/docs/source/api/msticpy.context.tiproviders.mblookup.rst
+++ b/docs/source/api/msticpy.context.tiproviders.mblookup.rst
@@ -1,0 +1,7 @@
+msticpy.context.tiproviders.mblookup module
+===========================================
+
+.. automodule:: msticpy.context.tiproviders.mblookup
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/msticpy.context.tiproviders.rst
+++ b/docs/source/api/msticpy.context.tiproviders.rst
@@ -21,6 +21,7 @@ Submodules
    msticpy.context.tiproviders.intsights
    msticpy.context.tiproviders.kql_base
    msticpy.context.tiproviders.lookup_result
+   msticpy.context.tiproviders.mblookup
    msticpy.context.tiproviders.open_page_rank
    msticpy.context.tiproviders.preprocess_observable
    msticpy.context.tiproviders.result_severity

--- a/msticpy/data/sql_to_kql.py
+++ b/msticpy/data/sql_to_kql.py
@@ -8,9 +8,11 @@ Module for SQL to KQL Conversion.
 
 This is an experiment conversion utility built to support a limited subset
 of ANSI SQL.
-It relies on moz_sql_parser (https://github.com/mozilla/moz-sql-parser)
+
+It relies on mo_sql_parsing (a maintained fork from the deprecated
+https://github.com/mozilla/moz-sql-parser)
 to parse the SQL syntax tree. Some hacky additions have been done to
-allow table renaming and support for a few SparkSQL operators such as
+allow table renaming and support for non ANSI SQL operators such as
 RLIKE.
 
 For a more complete translation help with SQL to KQL see
@@ -24,15 +26,18 @@ Known limitations
 - Only partial support for AS naming (should work in SELECT expressions)
 
 """
+
 import random
 import re
+from collections import namedtuple
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ..common.exceptions import MsticpyImportExtraError
 
 try:
-    import moz_sql_parser
-    from moz_sql_parser import parse
+    # import moz_sql_parser
+    # from moz_sql_parser import parse
+    from mo_sql_parsing import parse
 except ImportError as imp_err:
     raise MsticpyImportExtraError(
         "Cannot use this feature without moz_sql_parser installed",
@@ -48,45 +53,48 @@ __author__ = "Ian Hellen"
 
 _DEBUG = False
 
-SPARK_KQL_FUNC_MAP = {
-    "avg": ("avg", None, None),
-    "base64": ("base64_encode_tostring", None, None),
-    "concat": ("strcat", None, None),
-    "count": ("count", None, None),
-    "if": ("iif", None, None),
-    "iif": ("iif", None, None),
-    "ifnull": (None, None, "iif(isnull({p0}), {p1}, {p0}))"),
-    "in": ("in", None, None),
-    "instr": ("indexof", None, None),
-    "int": ("toint", None, None),
-    "isnotnull": ("isnotnull", None, None),
-    "isnull": ("isnull", None, None),
-    "left": ("NA", None, None),
-    "length": ("strlen", None, None),
-    "like": ("NA", None, None),
-    "locate": ("indexof", None, None),
-    "lower": ("tolower", None, None),
-    "lcase": ("tolower", None, None),
-    "ltrim": ("trim_start", None, None),
-    "max": ("max", None, None),
-    "mean": ("mean", None, None),
-    "min": ("min", None, None),
-    "position": ("indexof", None, None),
-    "regexp_extract": ("extract", "{p1}, {p0}", None),  # swap params 0, 1
-    "replace": ("replace", None, None),
-    "reverse": ("reverse", None, None),
-    "rtrim": ("trim_end", None, None),
-    "split": ("split", None, None),
-    "string": ("tostring", None, None),
-    "str": ("tostring", None, None),
-    "substr": ("substring", None, None),
-    "substring": ("substring", None, None),
-    "sum": ("sum", None, None),
-    "todatetime": ("to_date", None, None),
-    "translate": ("translate", None, None),
-    "trim": ("trim", None, None),
-    "unbase64": ("base64_decode_tostring", None, None),
-    "upper": ("toupper", None, None),
+FuncFormat = namedtuple("FuncFormat", "default, cust_arg_fmt, cust_func_format")
+
+SQL_KQL_FUNC_MAP = {
+    "add": FuncFormat(None, None, "{p0} + {p1}"),
+    "avg": FuncFormat("avg", None, None),
+    "base64": FuncFormat("base64_encode_tostring", None, None),
+    "concat": FuncFormat("strcat", None, None),
+    "count": FuncFormat("count", None, None),
+    "if": FuncFormat("iif", None, None),
+    "iif": FuncFormat("iif", None, None),
+    "ifnull": FuncFormat(None, None, "iif(isnull({p0}), {p1}, {p0}))"),
+    "in": FuncFormat("in", None, None),
+    "instr": FuncFormat("indexof", None, None),
+    "int": FuncFormat("toint", None, None),
+    "isnotnull": FuncFormat("isnotnull", None, None),
+    "isnull": FuncFormat("isnull", None, None),
+    "left": FuncFormat("NA", None, None),
+    "length": FuncFormat("strlen", None, None),
+    "like": FuncFormat("NA", None, None),
+    "locate": FuncFormat("indexof", None, None),
+    "lower": FuncFormat("tolower", None, None),
+    "lcase": FuncFormat("tolower", None, None),
+    "ltrim": FuncFormat("trim_start", None, None),
+    "max": FuncFormat("max", None, None),
+    "mean": FuncFormat("mean", None, None),
+    "min": FuncFormat("min", None, None),
+    "position": FuncFormat("indexof", None, None),
+    "regexp_extract": FuncFormat("extract", "{p1}, {p0}", None),  # swap params 0, 1
+    "replace": FuncFormat("replace", None, None),
+    "reverse": FuncFormat("reverse", None, None),
+    "rtrim": FuncFormat("trim_end", None, None),
+    "split": FuncFormat("split", None, None),
+    "string": FuncFormat("tostring", None, None),
+    "str": FuncFormat("tostring", None, None),
+    "substr": FuncFormat("substring", None, None),
+    "substring": FuncFormat("substring", None, None),
+    "sum": FuncFormat("sum", None, None),
+    "todatetime": FuncFormat("to_date", None, None),
+    "translate": FuncFormat("translate", None, None),
+    "trim": FuncFormat("trim", None, None),
+    "unbase64": FuncFormat("base64_decode_tostring", None, None),
+    "upper": FuncFormat("toupper", None, None),
 }
 
 
@@ -116,16 +124,19 @@ LEFT_OUTER_JOIN = "left outer join"
 LIKE = "like"
 LIMIT = "limit"
 NOT = "not"
-NOT_BETWEEN = "not between"
-NOT_IN = "not in"
-NOT_LIKE = "not like"
+NOT_BETWEEN = "not_between"
+NOT_IN = "nin"
+NOT_LIKE = "not_like"
+NOT_RLIKE = "not_rlike"
 OFFSET = "offset"
 ON = "on"
 OR = "or"
 ORDER_BY = "orderby"
 RIGHT_JOIN = "right join"
 RIGHT_OUTER_JOIN = "right outer join"
+RLIKE = "rlike"
 SELECT = "select"
+SELECT_DISTINCT = "select_distinct"
 THEN = "then"
 UNION = "union"
 UNION_ALL = "union all"
@@ -133,10 +144,6 @@ USING = "using"
 WHEN = "when"
 WHERE = "where"
 WITH = "with"
-
-# override/add keywords
-RLIKE = "rlike"
-
 
 JOIN_KEYWORDS = {
     FULL_JOIN: "outer",
@@ -151,20 +158,31 @@ JOIN_KEYWORDS = {
 }
 JOIN_KEYWORDS = {kw.replace("_", " "): kql for kw, kql in JOIN_KEYWORDS.items()}
 
-
-BINARY_OPS = {val: key for key, val in moz_sql_parser.keywords.binary_ops.items()}
-BINARY_OPS["eq"] = "=="
-BINARY_OPS["neq"] = "!="
-BINARY_OPS["nin"] = "!in"
-BINARY_OPS["rlike"] = "not matches regex"
-BINARY_OPS["nlike"] = "not matches regex"
-BINARY_OPS["concat"] = "+"
-BINARY_OPS["is"] = "=="
-BINARY_OPS["is not"] = "!="
-
-
-REMAPPED_KEYWORDS = {"RLIKE": "LIKE"}
-
+BINARY_OPS = {
+    "concat": "concat",
+    "mul": "*",
+    "div": "/",
+    "mod": "%",
+    "add": "+",
+    "sub": "-",
+    "binary_and": "binary_and",
+    "binary_or": "binary_or",
+    "binary_xor": "binary_xor",
+    "lt": "<",
+    "lte": "<=",
+    "gt": ">",
+    "gte": ">=",
+    "not_between": "not_between",
+    "or": "or",
+    "and": "and",
+    "eq": "==",
+    "neq": "!=",
+    "nin": "!in",
+    "rlike": "matches regex",
+    "not_rlike": "not matches regex",
+    "is": "==",
+    "is_not": "!=",
+}
 
 # noqa: MC0001
 
@@ -179,7 +197,7 @@ def sql_to_kql(sql: str, target_tables: Dict[str, str] = None) -> str:
         for table in target_tables:
             sql = sql.replace(table, target_tables[table])
     # replace keywords
-    sql = _remap_kewords(sql)
+    # sql = _remap_kewords(sql)
     parsed_sql = parse(sql)
     query_lines = _parse_query(parsed_sql)
     return "\n".join(line for line in query_lines if line.strip())
@@ -199,12 +217,16 @@ def _parse_query(parsed_sql: Dict[str, Any]) -> List[str]:  # noqa: MC0001
         _process_group_by(parsed_sql, query_lines)
         # Get rid of the SELECT statement since we've processed it in
         # the groupby
-        parsed_sql.pop(SELECT)
+        parsed_sql.pop(SELECT, parsed_sql.pop(SELECT_DISTINCT, None))
 
     distinct_select: List[Dict[str, Any]] = []
+    if SELECT_DISTINCT in parsed_sql:
+        distinct_select.extend(parsed_sql[SELECT_DISTINCT])
+        _process_select(
+            parsed_sql[SELECT_DISTINCT], parsed_sql[SELECT_DISTINCT], query_lines
+        )
     if SELECT in parsed_sql:
-        distinct_select, expr_list = _is_distinct(parsed_sql[SELECT])
-        _process_select(parsed_sql[SELECT], expr_list, query_lines)
+        _process_select(parsed_sql[SELECT], parsed_sql[SELECT], query_lines)
     if ORDER_BY in parsed_sql:
         query_lines.append(f"| order by {_create_order_by(parsed_sql[ORDER_BY])}")
     if distinct_select:
@@ -233,7 +255,7 @@ def _process_from(
     if isinstance(from_expr, dict) and UNION in from_expr:
         query_lines.extend(_parse_query(from_expr))
     elif isinstance(from_expr, dict):
-        query_lines.extend(_parse_query(from_expr["value"]))
+        query_lines.extend(_parse_query(from_expr))
     elif isinstance(from_expr, str):
         query_lines.append((from_expr))
         return
@@ -328,7 +350,7 @@ def _process_group_by(parsed_sql: Dict[str, Any], query_lines: List[str]):
     )
     by_clause = ", ".join(val["value"] for val in group_by_expr if val.get("value"))
 
-    _, expr_list = _is_distinct(parsed_sql[SELECT])
+    expr_list = parsed_sql.get(SELECT, parsed_sql.get(SELECT_DISTINCT, []))
     group_by_expr_list = []
     expr_list = _get_expr_value(expr_list)
     for expr in expr_list:
@@ -352,9 +374,13 @@ def _parse_expression(expression):  # noqa: MC0001
     if not isinstance(expression, dict):
         return expression
     if AND in expression:
-        return "\n  and ".join([_parse_expression(expr) for expr in expression[AND]])
+        return "\n  and ".join(
+            [f"({_parse_expression(expr)})" for expr in expression[AND]]
+        )
     if OR in expression:
-        return "\n  or ".join([_parse_expression(expr) for expr in expression[OR]])
+        return "\n  or ".join(
+            [f"({_parse_expression(expr)})" for expr in expression[OR]]
+        )
     if NOT in expression:
         return f" not ({_parse_expression(expression[NOT])})"
     if BETWEEN in expression:
@@ -364,7 +390,7 @@ def _parse_expression(expression):  # noqa: MC0001
     if NOT_BETWEEN in expression:
         args = expression[NOT_BETWEEN]
         betw_expr = f"{_parse_expression(args[1])} .. {_parse_expression(args[2])}"
-        return f"{args[0]} not between ({betw_expr})"
+        return f"{args[0]} !between ({betw_expr})"
     if IN in expression or NOT_IN in expression:
         sql_op = IN if IN in expression else NOT_IN
         kql_op = IN if IN in expression else "!in"
@@ -379,7 +405,7 @@ def _parse_expression(expression):  # noqa: MC0001
         return f"{args[0]} {kql_op} ({sub_query})"
 
     # Handle other operators
-    oper = list(expression.keys())[0] if expression else None
+    oper = next(iter(expression.keys())) if expression else None
     if oper in BINARY_OPS:
         right = _parse_expression(expression[oper][1])
         left = _parse_expression(expression[oper][0])
@@ -391,6 +417,8 @@ def _parse_expression(expression):  # noqa: MC0001
     if expression:
         func, operand = next(iter(expression.items()))
         #         set_trace()
+        if isinstance(operand, list):
+            return _map_func(func, *operand)
         return _map_func(func, operand)
     return "EXPRESSION {expression} not resolved."
 
@@ -403,10 +431,10 @@ def _map_func(func: str, *args) -> str:
     func = func.lower().strip()
     args_dict = {f"p{idx}": arg for idx, arg in enumerate(args)}
     def_arg_fmt = ", ".join(f"{{{arg}}}" for arg in args_dict)
-    if func not in SPARK_KQL_FUNC_MAP:
+    if func not in SQL_KQL_FUNC_MAP:
         func_fmt = f"{func}({def_arg_fmt}) // WARNING unmapped function\n"
         return func_fmt.format(**args_dict)
-    func_map = SPARK_KQL_FUNC_MAP[func]
+    func_map = SQL_KQL_FUNC_MAP[func]
 
     if (
         func == "count"
@@ -416,14 +444,14 @@ def _map_func(func: str, *args) -> str:
         func_arg = _get_expr_value(args[0]["distinct"])
         return f"dcount({func_arg})"
 
-    if not func_map[1] and not func_map[2]:
-        func_fmt = f"{func_map[0]}({def_arg_fmt})"
+    if not func_map.cust_arg_fmt and not func_map.cust_func_format:
+        func_fmt = f"{func_map.default}({def_arg_fmt})"
         return func_fmt.format(**args_dict)
-    if func_map[1]:
-        func_fmt = f"{func_map[0]}({func_map[1]})"
+    if func_map.cust_arg_fmt:
+        func_fmt = f"{func_map.default}({func_map.cust_arg_fmt})"
         return func_fmt.format(**args_dict)
-    if func_map[2]:
-        func_fmt = f"{func_map[2]}"
+    if func_map.cust_func_format:
+        func_fmt = f"{func_map.cust_func_format}"
         return func_fmt.format(**args_dict)
     raise ValueError(f"Could not map function or args {func}{args_dict}")
 
@@ -457,37 +485,6 @@ def _quote(expr: str) -> str:
 def _single_quote_strings(sql: str) -> str:
     """Replace unquoted double-quotes with single-quotes."""
     return re.sub(r"(?<![\\])\"", "'", sql)
-
-
-def _remap_kewords(sql: str) -> str:
-    """Replace keywords in source SQL statement."""
-    for repl_kw, mapped_kw in REMAPPED_KEYWORDS.items():
-        sql = re.sub(f"\\s{repl_kw}\\s", f" {mapped_kw} ", sql)
-    return sql
-
-
-def _is_distinct(
-    select_list: Union[Dict[str, Any], List[Dict[str, Any]]]
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-    """Check for DISTINCT in SELECT clause."""
-    select_list_out = []
-    dist_list: List[Dict[str, Any]] = []
-    dist_dict = _get_expr_value(select_list)
-
-    if isinstance(dist_dict, dict) and DISTINCT in dist_dict:
-        dist_list = dist_dict.pop(DISTINCT)
-        # Keep distinct items in the select list
-        return dist_list, dist_list
-
-    if isinstance(select_list, dict):
-        select_list = [select_list]
-    if isinstance(select_list, list):
-        for expr in select_list:
-            _db_print(expr)
-            if "value" in expr and DISTINCT in expr["value"]:
-                dist_list.append({"value": _get_expr_value(expr["value"][DISTINCT])})
-            select_list_out.append(expr)
-    return dist_list, select_list_out
 
 
 def _format_order_item(item: Dict[str, Any]) -> str:

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -28,7 +28,7 @@ KqlmagicCustom[jupyter-basic,auth_code_clipboard]>=0.1.114
 KqlmagicCustom[jupyter-extended]>=0.1.114
 lxml>=4.6.3
 matplotlib>=3.0.0
-moz_sql_parser>=4.5.0,<=4.11.21016
+mo-sql-parsing>=8
 msal>=1.12.0
 msal_extensions>=0.3.0
 msrest>=0.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.7.4
-async_lru>=1.0.2
+async-cache>=1.1.1
 bandit>=1.7.0
 beautifulsoup4
 black>=20.8b1

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EXTRAS = {
         "keyring>=13.2.1",  # needed by Key Vault package
     ],
     "ml": ["scikit-learn>=0.20.2", "scipy>=1.1.0", "statsmodels>=0.11.1"],
-    "sql2kql": ["moz_sql_parser>=4.5.0,<=4.11.21016"],
+    "sql2kql": ["mo-sql-parsing>=8"],
     "riskiq": ["passivetotal>=2.5.3"],
 }
 extras_all = [

--- a/tests/data/test_sql_to_kql.py
+++ b/tests/data/test_sql_to_kql.py
@@ -26,11 +26,11 @@ SQL_CASES = [
         """,
         kql="""
         SecurityEvent
-        | where Channel == 'Microsoft-Windows-Sysmon/Operational'
-        and EventID between (1 .. 10)
-        and tolower(ParentImage) endswith 'explorer.exe'
-        and EventID in ('4', '5', '6')
-        and tolower(Image) startswith '3aka3'
+        | where (Channel == 'Microsoft-Windows-Sysmon/Operational')
+        and (EventID between (1 .. 10))
+        and (tolower(ParentImage) endswith 'explorer.exe')
+        and (EventID in ('4', '5', '6'))
+        and (tolower(Image) startswith '3aka3')
         | project Message, Otherfield
         | distinct Message, Otherfield
         | limit 10
@@ -56,12 +56,12 @@ SQL_CASES = [
         apt29Host
         | project EventID, ParentImage, Image, Message, Otherfield
         | join kind=inner (MyTable
-        | project Message, foo) on $right.Message == $left.Message
-        and $right.foo == $left.EventID
-        | where Channel == 'Microsoft-Windows-Sysmon/Operational'
-        and EventID == 1
-        and tolower(ParentImage) endswith 'explorer.exe'
-        and tolower(Image) startswith '.*3aka3'
+        | project Message, foo) on ($right.Message == $left.Message)
+        and ($right.foo == $left.EventID)
+        | where (Channel == 'Microsoft-Windows-Sysmon/Operational')
+        and (EventID == 1)
+        and (tolower(ParentImage) endswith 'explorer.exe')
+        and (tolower(Image) matches regex '.*3aka3%')
         | summarize any(Message), any(Otherfield), dcount(EventID) by EventID
         | order by Message desc, Otherfield
         | limit 10
@@ -82,21 +82,21 @@ SQL_CASES = [
                 AND LOWER(Image) LIKE '%cmd.exe'
         ) b
         ON a.ParentProcessGuid = b.ProcessGuid
-        WHERE Channel = "Microsoft-Windows-Sysmon/Operational"
-            AND EventID = 1
-            AND LOWER(Image) LIKE '%powershell.exe'
+        WHERE (Channel = "Microsoft-Windows-Sysmon/Operational"
+            AND EventID = 1)
+            OR LOWER(Image) LIKE '%powershell.exe'
         """,
         kql="""
         apt29Host
         | join kind=inner (apt29Host
-        | where Channel == 'Microsoft-Windows-Sysmon/Operational'
-        and EventID == 1
-        and tolower(ParentImage) matches regex '.*\â€Ž|â€|â€ª|â€«|â€¬|â€|â€®.*'
-        and tolower(Image) endswith 'cmd.exe'
+        | where (Channel == 'Microsoft-Windows-Sysmon/Operational')
+        and (EventID == 1)
+        and (tolower(ParentImage) matches regex '.*\â€Ž|â€|â€ª|â€«|â€¬|â€|â€®.*')
+        and (tolower(Image) endswith 'cmd.exe')
         | project ProcessGuid) on $left.ParentProcessGuid == $right.ProcessGuid
-        | where Channel == 'Microsoft-Windows-Sysmon/Operational'
-        and EventID == 1
-        and tolower(Image) endswith 'powershell.exe'
+        | where ((Channel == 'Microsoft-Windows-Sysmon/Operational')
+        and (EventID == 1))
+        or (tolower(Image) endswith 'powershell.exe')
         | project Message
         """,
         id="join2",
@@ -116,6 +116,11 @@ SQL_CASES = [
                 AND EventID = 1
                 AND LOWER(ParentImage) LIKE "%explorer.exe"
                 AND LOWER(Image) RLIKE ".*3aka3%"
+                AND (EventID >= 0
+                OR EventID IN (1, 2, 3, 4))
+                AND EventID NOT IN (5, 6)
+                AND EventID <= 2
+                AND (EventID & 2) = 2
             LIMIT 10
             )
         GROUP BY Message
@@ -127,10 +132,15 @@ SQL_CASES = [
         | union (apt29Host
         | project EventID, ParentImage, Image, Message, Otherfield
         | join kind=inner (MyTable) on $right.mssg == $left.Message
-        | where Channel == 'Microsoft-Windows-Sysmon/Operational'
-        and EventID == 1
-        and tolower(ParentImage) endswith 'explorer.exe'
-        and tolower(Image) startswith '.*3aka3'
+        | where (Channel == 'Microsoft-Windows-Sysmon/Operational')
+        and (EventID == 1)
+        and (tolower(ParentImage) endswith 'explorer.exe')
+        and (tolower(Image) matches regex '.*3aka3%')
+        and ((EventID >= 0)
+        or (EventID in (1, 2, 3, 4)))
+        and (EventID !in (5, 6))
+        and (EventID <= 2)
+        and (EventID binary_and 2 == 2)
         | project Message, Otherfield, EventID
         | distinct Message, Otherfield, EventID
         )
@@ -157,9 +167,9 @@ SQL_CASES = [
         apt29Host
         | extend ParentMessage = ParentImage + Message, Otherfield = tolower(Otherfield)
         | project ID = EventID, ParentImage, Image, Message, ParentMessage, Otherfield
-        | where Channel == 'Microsoft-Windows-Sysmon/Operational'
-        and EventID == 1
-        and tolower(ParentImage) endswith 'explorer.exe'
+        | where (Channel == 'Microsoft-Windows-Sysmon/Operational')
+        and (EventID == 1)
+        and (tolower(ParentImage) endswith 'explorer.exe')
         | extend Otherfield = count(Otherfield)
         | project mssg = ParentMessage, Otherfield
         | distinct *

--- a/tools/toollib/import_analyzer.py
+++ b/tools/toollib/import_analyzer.py
@@ -51,9 +51,7 @@ _PKG_RENAME_NAME = {
     "dateutil": "python-dateutil",
     "splunklib": "splunk-sdk",
     "sumologic": "sumologic-sdk",
-    "typing_extensions": "typing-extensions",
     "vt": "vt-py",
-    "vt_graph_api": "vt-graph-api",
     "kqlmagic": "KqlmagicCustom",
 }
 
@@ -266,11 +264,12 @@ def get_setup_reqs(
     az_mgmt_reqs = {
         pkg.replace("-", "."): pkg for pkg in setup_reqs if pkg.startswith("azure-")
     }
-
     for key, pkg in az_mgmt_reqs.items():
         setup_reqs.pop(pkg)
         setup_reqs[key] = pkg
 
+    # remap packages with "-" in the name with "_" to be valid Python identifiers
+    setup_reqs = {key.replace("-", "_"): value for key, value in setup_reqs.items()}
     return setup_reqs, setup_versions
 
 
@@ -283,7 +282,7 @@ def get_extras_from_setup(
 
     Parameters
     ----------
-    extra : str, optiona
+    extra : str, optional
         The name of the extra to return, by default "all"
     include_base : bool, optional
         If True include install_requires, by default False

--- a/tools/toollib/url_checker_async.py
+++ b/tools/toollib/url_checker_async.py
@@ -12,8 +12,8 @@ from urllib import parse
 
 import markdown
 from aiohttp import ClientConnectionError, ClientResponseError, ClientSession
-from async_lru import alru_cache
 from bs4 import BeautifulSoup
+from cache import AsyncLRU
 
 # pylint: disable=relative-beyond-top-level
 # from . import VERSION
@@ -321,7 +321,7 @@ def check_uris(
     return loop.run_until_complete(future)
 
 
-@alru_cache(maxsize=256)
+@AsyncLRU(maxsize=256)
 async def _check_url_async(url: str, session: ClientSession) -> UrlResult:
     """
     Connect to URL and return response status.


### PR DESCRIPTION
Several changes to sql_to_kql.py:
- updated import to use mo_sql_parsing
- several changes related to changed schema and keywords
- removed some hacky code related to older version of moz-sql-parser
- fixed several issues with incorrect operator mappings
- added parentheses (non-intelligent) around compound clauses to enforce evaluation order
[fix] Also replaced async-lru with async-cache (the former was old and caused deprecation warnings.
This only affects test code.
Also minor updates to docs ToC to sync with new code.