### PR TITLE
Fixing build issues with requirements-dev and doc

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,8 +58,8 @@ jobs:
             python -m pip install flake8 black bandit mypy lxml pylint types-attrs
             python -m pip install pytest pytest-cov pytest-xdist pytest-check aiohttp nbconvert jupyter_contrib_nbextensions
             python -m pip install Pygments respx pytest-xdist markdown beautifulsoup4 Pillow async-cache
-            python -m pip install "pandas>=1.3.0"
           fi
+          python -m pip install "pandas>=1.3.0"
       - name: Prepare test dummy data
         run: |
           mkdir ~/.msticpy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,9 +106,7 @@ stages:
         echo Env $MSTICPYCONFIG or %MSTICPYCONFIG%
         echo Build source: $(prSource)
         echo Env $MSTICPY_BUILD_SOURCE or %MSTICPY_BUILD_SOURCE%
-        python -m pip install --upgrade pytest pytest-azurepipelines
-        python -m pip install --upgrade pytest-cov pytest-check aiohttp nbconvert jupyter_contrib_nbextensions
-        python -m pip install --upgrade Pygments respx pytest-xdist markdown beautifulsoup4 Pillow async_lru
+        python -m pip install -r requirements-dev.txt
         python -m pip install "pandas>=1.3.0"
         pytest tests --junitxml=junit/test-$(variables.imageName)-$(variables.python.version)-results.xml -n auto --cov=msticpy --cov-report=xml
       displayName: pytest

--- a/conda/conda-reqs-dev-pip.txt
+++ b/conda/conda-reqs-dev-pip.txt
@@ -1,3 +1,5 @@
-
+async_lru>=1.0.2
 pyroma>=3.1
 pytest-check>=1.0.1
+pytest-xdist>=2.5.0
+types-attrs>=19.0.0

--- a/conda/conda-reqs-dev.txt
+++ b/conda/conda-reqs-dev.txt
@@ -9,6 +9,7 @@ isort>=5.10.1
 markdown>=3.3.4
 mccabe>=0.6.1
 mypy>=0.821
+nbconvert>=6.1.0
 nbdime>=2.1.0
 pandas>=1.4.0
 pep8-naming>=0.10.0

--- a/docs/source/data_acquisition/WritingADataProvider.rst
+++ b/docs/source/data_acquisition/WritingADataProvider.rst
@@ -3,8 +3,7 @@ Writing and Contributing a Data Provider
 
 A data provider lets you query data from a notebook in a standardized way.
 Before reading further you should familiarize yourself with how the data
-providers work from the
-`Querying and Importing Data <https://msticpy.readthedocs.io/DataAcquisition.html>`_
+providers work from the :doc:`Querying and Importing Data <../DataAcquisition>`
 section of the MSTICPy documentation.
 
 The term provider is more a concept than defining a single piece of code.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 aiohttp>=3.7.4
 async_lru>=1.0.2
+async-cache>=1.1.1
 bandit>=1.7.0
 beautifulsoup4
 black>=20.8b1
@@ -12,6 +13,7 @@ markdown>=3.3.4
 mccabe>=0.6.1
 mypy>=0.812
 nbdime>=2.1.0
+nbconvert>=6.1.0
 pandas>=1.2.5
 pep8-naming>=0.10.0
 pep8>=1.7.1
@@ -25,9 +27,11 @@ pylint>=2.5.3
 pyroma>=3.1
 pytest-check>=1.0.1
 pytest-cov>=2.11.1
+pytest-xdist>=2.5.0
 pytest>=5.0.1
 readthedocs-sphinx-ext==2.1.8
 responses>=0.13.2
 respx==0.19.2
 sphinx-rtd-theme>=1.0.0
 sphinx>=5.0.1
+types-attrs>=19.0.0


### PR DESCRIPTION
- install test requirements from requirements-dev.txt in azure-pipelines.yml and GitHub python-package.yml
- pytest-xdist not in requirements-dev.txt
- adding async-cache, nbconvert, types-attrs to requirements-dev.txt
Corresponding changes made in conda-reqs-dev.txt and conda-reqs-dev-pip.txt
Fixing incorrect URL/doc reference in WritingADataProvider.rst