### PR TITLE
Rolling back change on _build_chained_creds

### DIFF
--- a/msticpy/auth/azure_auth_core.py
+++ b/msticpy/auth/azure_auth_core.py
@@ -302,7 +302,7 @@ def _build_chained_creds(
         raise MsticpyAzureConfigError(
             "At least one valid authentication method required."
         )
-    return ChainedTokenCredential([client for client in clients if client])  # type: ignore
+    return ChainedTokenCredential(*[client for client in clients if client])  # type: ignore
 
 
 class _AzCachedConnect:


### PR DESCRIPTION
ChainedTokenCredential constructor expects a TokenCredential but is sent a list https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.chainedtokencredential?view=azure-python

Error triggered when calling `self._get_working_kv_client(kv_client)` (l181 of msticpy/auth/keyvault_client.py)

`azure.core.exceptions.ClientAuthenticationError: ChainedTokenCredential failed to retrieve a token from the included credentials.
Attempted credentials:
	list: 'list' object has no attribute 'get_token'
To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azsdk/python/identity/defaultazurecredential/troubleshoot.`