### PR TITLE
[fix] bug in call to ChainTokenCredential breaks all authentication

### DIFF
--- a/msticpy/_version.py
+++ b/msticpy/_version.py
@@ -1,2 +1,2 @@
 """Version file."""
-VERSION = "2.1.1"
+VERSION = "2.1.2"

--- a/msticpy/auth/azure_auth_core.py
+++ b/msticpy/auth/azure_auth_core.py
@@ -302,7 +302,7 @@ def _build_chained_creds(
         raise MsticpyAzureConfigError(
             "At least one valid authentication method required."
         )
-    return ChainedTokenCredential([client for client in clients if client])  # type: ignore
+    return ChainedTokenCredential(*clients)  # type: ignore
 
 
 class _AzCachedConnect:


### PR DESCRIPTION
Bad bug in azure_auth_core.py that causes all authentication to fail.
Thx to @FlorianBracq who reported and provided a fix for this before we found it.