### PR TITLE
Sentinel - Return all saved queries

### DIFF
--- a/msticpy/context/azure/sentinel_analytics.py
+++ b/msticpy/context/azure/sentinel_analytics.py
@@ -42,6 +42,23 @@ class SentinelHuntingMixin:
 
     get_hunting_queries = list_hunting_queries
 
+    def list_saved_queries(self) -> pd.DataFrame:
+        """
+        Return all saved queries in a Microsoft Sentinel workspace.
+
+        Returns
+        -------
+        pd.DataFrame
+            A table of the custom hunting queries.
+
+        """
+        saved_query_df = self._list_items(  # type: ignore
+            item_type="ss_path", api_version="2020-08-01"
+        )
+        return saved_query_df
+
+    get_hunting_queries = list_hunting_queries
+
 
 class SentinelAnalyticsMixin:
     """Mixin class for Sentinel Analytics feature integrations."""

--- a/tests/context/azure/test_sentinel_analytics.py
+++ b/tests/context/azure/test_sentinel_analytics.py
@@ -34,7 +34,24 @@ _HUNTING_QUERIES = {
             },
             "name": "123",
             "type": "Microsoft.OperationalInsights/savedSearches",
-        }
+        },
+        {
+            "id": "subscriptions/123/resourceGroups/RG/providers/Microsoft.OperationalInsights/workspaces/WSNAME/savedSearches/123",
+            "etag": "Tag",
+            "properties": {
+                "category": "Saved Queries",
+                "DisplayName": "SavedQueries",
+                "Query": "SavedQueryText",
+                "Tags": [
+                    {"Name": "description", "Value": ""},
+                    {"Name": "tactics", "Value": ""},
+                    {"Name": "t-skang@microsoft.com", "Value": "false"},
+                ],
+                "Version": 2,
+            },
+            "name": "123",
+            "type": "Microsoft.OperationalInsights/savedSearches",
+        },
     ],
 }
 _ALERT_RULES = {
@@ -99,7 +116,20 @@ def test_sent_hunting_queries(sent_loader):
     )
     hqs = sent_loader.list_hunting_queries()
     assert isinstance(hqs, pd.DataFrame)
+    assert 1 == len(hqs.index)
     assert hqs["properties.Query"].iloc[0] == "QueryText"
+
+
+@respx.mock
+def test_sent_saved_queries(sent_loader):
+    """Test Sentinel hunting feature."""
+    respx.get(re.compile(r"https://management\.azure\.com/.*")).respond(
+        200, json=_HUNTING_QUERIES
+    )
+    sqs = sent_loader.list_saved_queries()
+    assert isinstance(sqs, pd.DataFrame)
+    assert 2 == len(sqs.index)
+    assert sqs["properties.Query"].iloc[1] == "SavedQueryText"
 
 
 @respx.mock


### PR DESCRIPTION
Added function to MicrosoftSentinel feature to return all saved queries from a workspace.
Previous functionality could only return Hunting Queries.