### PR TITLE
process_tree: Accept GUID format for ProcessID and ParentProcessID

### DIFF
--- a/msticpy/vis/mp_pandas_plot.py
+++ b/msticpy/vis/mp_pandas_plot.py
@@ -277,8 +277,8 @@ class MsticpyPlotAccessor:
         hide_legend : bool, optional
             Hide the legend box, even if legend_col is specified.
         pid_fmt : str, optional
-            Display Process ID as 'dec' (decimal) or 'hex' (hexadecimal),
-            default is 'hex'.
+            Display Process ID as 'dec' (decimal), 'hex' (hexadecimal),
+            or 'guid' (string), default is 'hex'.
 
         Returns
         -------

--- a/msticpy/vis/process_tree.py
+++ b/msticpy/vis/process_tree.py
@@ -103,7 +103,7 @@ def build_and_show_process_tree(
         Hide the legend box, even if legend_col is specified.
     pid_fmt : str, optional
         Display Process ID as 'dec' (decimal) or 'hex' (hexadecimal),
-        default is 'hex'.
+        'guid' (string), default is 'hex'.
 
     Returns
     -------
@@ -173,7 +173,7 @@ def plot_process_tree(  # noqa: MC0001
     hide_legend : bool, optional
         Hide the legend box, even if legend_col is specified.
     pid_fmt : str, optional
-        Display Process ID as 'dec' (decimal) or 'hex' (hexadecimal),
+        Display Process ID as 'dec' (decimal), 'hex' (hexadecimal), 'guid' (string)
         default is 'hex'.
 
     Returns
@@ -390,6 +390,8 @@ def _pre_process_tree(
 def _pid_fmt(pid, pid_fmt):
     if pid_fmt == "hex":
         return f"PID: {pid}" if str(pid).startswith("0x") else f"PID: 0x{int(pid):x}"
+    elif pid_fmt == "guid":
+        return f"GUID: {pid}"
     return (
         f"PID: {pid}" if not str(pid).startswith("0x") else f"PID: {int(pid, base=16)}"
     )

--- a/msticpy/vis/process_tree.py
+++ b/msticpy/vis/process_tree.py
@@ -102,8 +102,8 @@ def build_and_show_process_tree(
     hide_legend : bool, optional
         Hide the legend box, even if legend_col is specified.
     pid_fmt : str, optional
-        Display Process ID as 'dec' (decimal) or 'hex' (hexadecimal),
-        'guid' (string), default is 'hex'.
+        Display Process ID as 'dec' (decimal), 'hex' (hexadecimal),
+        or 'guid' (string), default is 'hex'.
 
     Returns
     -------
@@ -173,8 +173,8 @@ def plot_process_tree(  # noqa: MC0001
     hide_legend : bool, optional
         Hide the legend box, even if legend_col is specified.
     pid_fmt : str, optional
-        Display Process ID as 'dec' (decimal), 'hex' (hexadecimal), 'guid' (string)
-        default is 'hex'.
+        Display Process ID as 'dec' (decimal), 'hex' (hexadecimal),
+        or 'guid' (string), default is 'hex'.
 
     Returns
     -------
@@ -613,8 +613,8 @@ class ProcessTreeAccessor:
         hide_legend : bool, optional
             Hide the legend box, even if legend_col is specified.
         pid_fmt : str, optional
-            Display Process ID as 'dec' (decimal) or 'hex' (hexadecimal),
-            default is 'hex'.
+            Display Process ID as 'dec' (decimal), 'hex' (hexadecimal),
+            or 'guid' (string), default is 'hex'.
 
         Returns
         -------

--- a/msticpy/vis/process_tree.py
+++ b/msticpy/vis/process_tree.py
@@ -390,7 +390,7 @@ def _pre_process_tree(
 def _pid_fmt(pid, pid_fmt):
     if pid_fmt == "hex":
         return f"PID: {pid}" if str(pid).startswith("0x") else f"PID: 0x{int(pid):x}"
-    elif pid_fmt == "guid":
+    if pid_fmt == "guid":
         return f"GUID: {pid}"
     return (
         f"PID: {pid}" if not str(pid).startswith("0x") else f"PID: {int(pid, base=16)}"


### PR DESCRIPTION
Usually, I am trying all my best to never use PID/PPID in favor of their GUID versions because of the [PID recycling feature](https://justanothergeek.chdir.org/2020/07/is-processid-recycling-%EF%B8%8F-on-windows-over-rated/) that regularly bites me in the weirdest way.

Unfortunately, process_tree functions require PID... but they can accept GUID if we hack a bit `_pid_fmt`.

```python
proc_df['ProcessId'] = proc_df.ProcessGuid
proc_df['ParentProcessId'] = proc_df.ParentProcessGuid
p_tree_win = ptree.build_process_tree(proc_df, pid_fmt="guid")
ptree.plot_process_tree(p_tree_win)
```

This is totally a hack, I guess the real solution would be to accept the Guid versions as a first class citizen and you should reject this hackish PR 🤷 Sorry!

Without the patch, it errors with:

![image](https://user-images.githubusercontent.com/115087/196433227-863aeeae-9847-42ba-b47c-fae3a9a51b64.png)
