### PR TITLE
Fixed issues with dataprovider instances

### DIFF
--- a/msticpy/config/ce_common.py
+++ b/msticpy/config/ce_common.py
@@ -257,6 +257,7 @@ def get_wgt_ctrl(
     var_name: str,
     mp_controls: "MpConfigControls",  # type: ignore
     wgt_style: Optional[Dict[str, Any]] = None,
+    instance_path: str = None,
 ) -> widgets.Widget:
     """
     Return widget appropriate to value type of `var_name`.
@@ -277,6 +278,9 @@ def get_wgt_ctrl(
                 "style": {"description_width": "100px"},
                 "layout": widgets.Layout(width="50%")
             }
+    instance_path : Optional[str]
+        The path to the control settings, if different from
+        the definition path (e.g. ../path/Kusto-Cluster1)
 
     Returns
     -------
@@ -286,9 +290,10 @@ def get_wgt_ctrl(
     """
     if wgt_style is None:
         wgt_style = {}
-    var_path = f"{setting_path}.{var_name}"
+    var_path = f"{instance_path or setting_path}.{var_name}"
     ctrl = mp_controls.get_control(var_path)
-    comp_defn = mp_controls.get_defn(var_path)
+    defn_path = f"{setting_path}.{var_name}"
+    comp_defn = mp_controls.get_defn(defn_path)
     if comp_defn and not isinstance(comp_defn, tuple):
         # definition is a literal
         def_value = comp_defn

--- a/msticpy/config/ce_data_providers.py
+++ b/msticpy/config/ce_data_providers.py
@@ -82,6 +82,8 @@ class CEDataProviders(CEProviders):
     @property
     def _prov_ctrl_name(self):
         """Return the provider generic name (minus instance suffix)."""
+        if "-" in super()._prov_name:
+            return super()._prov_name.split("-", maxsplit=1)[0]
         return super()._prov_name
 
     @property
@@ -97,7 +99,9 @@ class CEDataProviders(CEProviders):
         return self.text_prov_instance.value.strip()
 
     def _populate_edit_ctrls(self, control_name: Optional[str] = None):
+        self.text_prov_instance.value = ""
         super()._populate_edit_ctrls(control_name=control_name)
+        self.text_prov_instance.value = self._prov_instance_name
         # add the instance text box
         self.edit_ctrls.children = [
             self.text_prov_instance,

--- a/msticpy/config/ce_provider_base.py
+++ b/msticpy/config/ce_provider_base.py
@@ -97,7 +97,7 @@ class CEProviders(CEItemsBase, ABC):
         self.prov_options = widgets.Dropdown(
             options=self.mp_controls.get_defn(path=self._COMP_PATH).keys(),
             description="Add prov",
-            value=self.select_item.label,
+            # value=self.select_item.label,
             style=ITEM_LIST_LAYOUT["style"],
         )
         self.items_frame.children = [*(self.items_frame.children), self.prov_options]
@@ -132,7 +132,10 @@ class CEProviders(CEItemsBase, ABC):
 
     def _populate_edit_ctrls(self, control_name: Optional[str] = None):
         self.edit_ctrls = _get_prov_ctrls(
-            control_name or self._prov_ctrl_name, self.mp_controls, self._COMP_PATH
+            prov_name=control_name or self._prov_ctrl_name,
+            mp_controls=self.mp_controls,
+            conf_path=self._COMP_PATH,
+            prov_instance_name=self._prov_name,
         )
         self.edit_frame.children = [self.edit_ctrls]
 
@@ -183,29 +186,44 @@ class CEProviders(CEItemsBase, ABC):
             self.set_status(status)
 
 
-def _get_prov_ctrls(prov_name, mp_controls, conf_path):
+def _get_prov_ctrls(prov_name, mp_controls, conf_path, prov_instance_name: str = None):
     ctrls = []
     if not prov_name:
         return widgets.VBox(ctrls, layout=CompEditDisplayMixin.no_border_layout("95%"))
-    prov_path = f"{conf_path}.{prov_name}"
-    prov_defn = mp_controls.get_defn(prov_path)
+    # prov_path = f"{conf_path}.{prov_name}"
+    instance_path = f"{conf_path}.{prov_instance_name or prov_name}"
+    defn_path = f"{conf_path}.{prov_name}"
+    prov_defn = mp_controls.get_defn(defn_path)
 
     for setting in prov_defn:
         if setting != "Args":
-            wgt = get_wgt_ctrl(prov_path, setting, mp_controls)
+            wgt = get_wgt_ctrl(
+                setting_path=defn_path,
+                var_name=setting,
+                mp_controls=mp_controls,
+                instance_path=instance_path,
+            )
             if setting == "Provider":
                 wgt.disabled = True
             ctrls.append(wgt)
             continue
 
-        setting_path = f"{prov_path}.{setting}"
+        setting_path = f"{instance_path}.{setting}"
+        setting_defn_path = f"{defn_path}.{setting}"
         for var_name in prov_defn.get(setting):
-            comp_defn = mp_controls.get_defn(f"{setting_path}.{var_name}")
+            comp_defn = mp_controls.get_defn(f"{setting_defn_path}.{var_name}")
             if get_defn_or_default(comp_defn)[0] == "cred_key":
                 arg_ctrl = get_arg_ctrl(setting_path, var_name, mp_controls)
                 ctrls.append(arg_ctrl.hbox)
             else:
-                ctrls.append(get_wgt_ctrl(setting_path, var_name, mp_controls))
+                ctrls.append(
+                    get_wgt_ctrl(
+                        setting_path=setting_defn_path,
+                        var_name=var_name,
+                        mp_controls=mp_controls,
+                        instance_path=setting_path,
+                    )
+                )
 
     return widgets.VBox(ctrls)
 


### PR DESCRIPTION
For DPs with instance suffixes I've added logic so that definitions are
looked up with the generic name (Kusto),
while settings are looked up using instance suffix (Kusto-instance)