### PR TITLE
Improved bug template getting rid of irrelevant sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,9 @@
 ---
 name: Bug report
+description: File a bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
+title: "[Bug]: "
+labels: ["bug", "triage"]
 assignees: ''
 
 ---
@@ -12,27 +13,24 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+
+1. Import z - `from msticpy.x.y import z`
+2. Run `method` - `z.method(param1="x", param2="y")`
+3. See error
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+**Screenshots and/or Traceback**
 If applicable, add screenshots to help explain your problem.
+Please include full traceback if possible/applicable.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Environment (please complete the following information):**
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+- Python Version: [e.g. 3.9]
+- OS: [e.g. Windows, Ubuntu, MacOS]
+- Python environment: [e.g. Local Python, Local Anaconda, Cloud Azure ML, Cloud Binder..]
+- MSTICPy Version: [e.g. v2.1.0]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
More specific format for python/notebook issues.
Seems that GitHub now has a more sophisticated bug template as a yaml - allowing things like drop-downs and other controls.
We should probably use that.