### PR TITLE
Inability to fetch "all" incidents, only 50

### DIFF
--- a/docs/source/data_acquisition/SentinelIncidents.rst
+++ b/docs/source/data_acquisition/SentinelIncidents.rst
@@ -4,7 +4,7 @@ Microsoft Sentinel Incidents
 List Incidents
 --------------
 
-It is possible to return a list of all incidents within a workspace, as well as get the details of a specific incident.
+It is possible to return a list incidents within a workspace, as well as get the details of a specific incident.
 Whilst it is possible to access these incident details via the Incident table in the Workspace, you can also interact
 with them via the Microsoft Sentinel APIs which are utilized in these functions.
 
@@ -14,7 +14,7 @@ See :py:meth:`get_incidents <msticpy.context.azure_sentinel.MicrosoftSentinel.li
 
     azs.list_incidents()
 
-This returns a DataFrame with details of all incidents.
+This returns a DataFrame with details of incidents.
 
 To get details of a single incident you can call `.get_incident` and pass the ID of an incident.
 This ID can be found in the name column of the DataFrame returned by `.get_incidents` and appears in the form of a GUID.


### PR DESCRIPTION
As far as I can tell, as of latest commit, d87b394e1f710d2ef2d86dcf9d88c8982787fd2f of sentinel_core.py, only 50 incidents are returned. 

The current implementation does not seem to respect the `nextLink` returned by the API and thus does not seem to paginate over incidents. 

(I also realize that some sort of limitation and filtering functionality would be very handy if one indeed were about to fetch "all"...)