### PR TITLE
Kql query formatting

### DIFF
--- a/msticpy/data/core/query_source.py
+++ b/msticpy/data/core/query_source.py
@@ -273,7 +273,13 @@ class QuerySource:
 
         if formatters and Formatters.PARAM_HANDLER in formatters:
             return formatters[Formatters.PARAM_HANDLER](self._query, **param_dict)
-        return self._query.format(**param_dict)
+        query = self._query.format(**param_dict)
+        # Remove empty lines if variables supposed to contain new pipe elements.
+        # Example:
+        # MyTable
+        # {timeCondition}
+        # | where key == "value"
+        return re.sub(r"\n\s*\n", "\n", query)
 
     def _format_parameter(self, p_name, param_dict, param_settings, formatters):
         # The parameter may need custom formatting

--- a/msticpy/data/core/query_source.py
+++ b/msticpy/data/core/query_source.py
@@ -431,7 +431,7 @@ class QuerySource:
                 fmt_list.append(f"'{item}'")
             else:
                 fmt_list.append(f"{item}")
-        return ",".join(fmt_list)
+        return ", ".join(fmt_list)
 
     def help(self):
         """Print help for query."""

--- a/msticpy/data/drivers/kql_driver.py
+++ b/msticpy/data/drivers/kql_driver.py
@@ -428,7 +428,7 @@ class KqlDriver(DriverBase):
                 fmt_list.append(f"'{item}'")
             else:
                 fmt_list.append(f"{item}")
-        return ",".join(fmt_list)
+        return ", ".join(fmt_list)
 
     @staticmethod
     def _raise_query_failure(query, result):

--- a/tests/data/test_query_source.py
+++ b/tests/data/test_query_source.py
@@ -169,7 +169,7 @@ class TestQuerySource(unittest.TestCase):
             ip_address_list=ip_address_list, start=test_start, end=test_end
         )
 
-        check_list = ",".join([f"'{ip}'" for ip in ip_address_list])
+        check_list = ", ".join([f"'{ip}'" for ip in ip_address_list])
         self.assertIn(check_list, query)
 
         ip_address_list = "192.168.0.1, 192.168.0.2, 192.168.0.3"
@@ -182,7 +182,7 @@ class TestQuerySource(unittest.TestCase):
         query = q_src.create_query(
             ip_address_list=int_list, start=test_start, end=test_end
         )
-        check_list = ",".join([str(i) for i in int_list])
+        check_list = ", ".join([str(i) for i in int_list])
         self.assertIn(check_list, query)
 
     def test_cust_formatters_kql(self):
@@ -212,7 +212,7 @@ class TestQuerySource(unittest.TestCase):
             start=test_start,
             end=test_end,
         )
-        check_list = ",".join([f"'{ip.strip()}'" for ip in ip_address_list.split(",")])
+        check_list = ", ".join([f"'{ip.strip()}'" for ip in ip_address_list.split(",")])
         self.assertIn(check_list, query)
 
         int_list = [1, 2, 3, 4]
@@ -222,7 +222,7 @@ class TestQuerySource(unittest.TestCase):
             start=test_start,
             end=test_end,
         )
-        check_list = ",".join([str(i) for i in int_list])
+        check_list = ", ".join([str(i) for i in int_list])
         self.assertIn(check_list, query)
 
 


### PR DESCRIPTION
Minor changes to improve formatting of KQL queries:
* Add a space to the list separator (", " instead of ",")
* Remove blank lines generated from variable" placeholder" that are not defined.
For instance:
```
MyTable
{timeCondition}
| where key == "value"
```

would generate with the current version
```
MyTable

| where key == "value"
```
instead of
```
MyTable
| where key == "value"
```