### PR TITLE
Add support for FireEye HX acquisition packages in `process_tree`

### DIFF
--- a/msticpy/transform/proc_tree_builder.py
+++ b/msticpy/transform/proc_tree_builder.py
@@ -15,6 +15,7 @@ from . import proc_tree_build_winlx as winlx
 # pylint: disable=unused-import
 from .proc_tree_schema import ProcSchema  # noqa: F401
 from .proc_tree_schema import (  # noqa: F401
+    HX_PROCESSEVENT_SCH,
     LX_EVENT_SCH,
     MDE_EVENT_SCH,
     MDE_INT_EVENT_SCH,

--- a/msticpy/transform/proc_tree_schema.py
+++ b/msticpy/transform/proc_tree_schema.py
@@ -249,7 +249,6 @@ HX_PROCESSEVENT_SCH = ProcSchema(
     process_id="pid",
     parent_name="parentprocess",
     parent_id="parentpid",
-    logon_id="uid",
     cmd_line="processcmdline",
     user_name="username",
     path_separator="\\",

--- a/msticpy/transform/proc_tree_schema.py
+++ b/msticpy/transform/proc_tree_schema.py
@@ -242,12 +242,29 @@ SYSMON_PROCESS_CREATE_EVENT_SCH = ProcSchema(
     host_name_column="Computer",
 )
 
+# HX ProcessEvent
+HX_PROCESSEVENT_SCH = ProcSchema(
+    time_stamp="starttime",
+    process_name="process",
+    process_id="pid",
+    parent_name="parentprocess",
+    parent_id="parentpid",
+    logon_id="uid",
+    cmd_line="processcmdline",
+    user_name="username",
+    path_separator="\\",
+    event_id_column="eventtype",
+    event_id_identifier="start",
+    host_name_column="hostname",
+)
+
 SUPPORTED_SCHEMAS = (
     WIN_EVENT_SCH,
     LX_EVENT_SCH,
     MDE_INT_EVENT_SCH,
     MDE_EVENT_SCH,
     SYSMON_PROCESS_CREATE_EVENT_SCH,
+    HX_PROCESSEVENT_SCH
 )
 
 

--- a/msticpy/transform/proc_tree_schema.py
+++ b/msticpy/transform/proc_tree_schema.py
@@ -242,7 +242,7 @@ SYSMON_PROCESS_CREATE_EVENT_SCH = ProcSchema(
     host_name_column="Computer",
 )
 
-# HX ProcessEvent
+# FireEye HX processEvent from 'stateagentinspector' or 'eventbuffer' audits
 HX_PROCESSEVENT_SCH = ProcSchema(
     time_stamp="starttime",
     process_name="process",


### PR DESCRIPTION
Hello 👋 this is just in case you are open to supporting third-party commercial tools.

FireEye's endpoint security HX product records process creation events and can make them available in data acquisition packages as XML structured data (see sample below). This is easily parsed into pandas DataFrames, and provides all required information for a `process_tree` schema.

I successfully tested this in a notebook, I could provide a sample acquisition package if needed.

```xml
<eventItem sequence_num="4257223597" uid="379727734">
    <timestamp>2023-01-11T06:21:59.774Z</timestamp>
    <eventType>processEvent</eventType>
    <details>
     <detail>
      <name>eventType</name>
      <value>start</value>
     </detail>
     <detail>
      <name>pid</name>
      <value>11604</value>
     </detail>
     <detail>
      <name>processPath</name>
      <value>C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe</value>
     </detail>
     <detail>
      <name>process</name>
      <value>msedge.exe</value>
     </detail>
     <detail>
      <name>parentPid</name>
      <value>17936</value>
     </detail>
     <detail>
      <name>parentProcessPath</name>
      <value>C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe</value>
     </detail>
     <detail>
      <name>parentProcess</name>
      <value>msedge.exe</value>
     </detail>
     <detail>
      <name>username</name>
      <value>SNIP_DOMAIN\SNIP_USER</value>
     </detail>
     <detail>
      <name>startTime</name>
      <value>2023-01-11T06:21:59.774Z</value>
     </detail>
     <detail>
      <name>md5</name>
      <value>0fd9e9bd708f1f69c9bb987cfc1f9a4c</value>
     </detail>
     <detail>
      <name>processCmdLine</name>
      <value>"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" SNIP_CMDLINE</value>
     </detail>
    </details>
   </eventItem>
```

Note: the hostname comes from another source inside the HX acquisition package and is added to the dataframe on the side.