### PR TITLE
Fixing RangeTool with bokeh 3.1.0 not a GestureTool

### DIFF
--- a/conda/conda-reqs.txt
+++ b/conda/conda-reqs.txt
@@ -10,7 +10,7 @@ azure-mgmt-network>=2.7.0
 azure-mgmt-resource>=16.1.0
 azure-storage-blob>=12.5.0
 beautifulsoup4>=4.0.0
-bokeh>=1.4.0, <=3.0.2
+bokeh>=1.4.0, <=3.1.0
 cryptography>=3.1
 deprecated>=1.2.4
 dnspython>=2.0.0, <3.0.0

--- a/msticpy/vis/process_tree.py
+++ b/msticpy/vis/process_tree.py
@@ -25,6 +25,7 @@ from bokeh.models import (  # type: ignore[attr-defined]
     HoverTool,
     LayoutDOM,
     RangeTool,
+    GestureTool,
 )
 from bokeh.models.widgets import DataTable, DateFormatter, TableColumn
 
@@ -534,7 +535,8 @@ def _create_vert_range_tool(
     rng_select.ygrid.grid_line_color = None
     rng_select.xgrid.grid_line_color = None
     rng_select.add_tools(range_tool)
-    rng_select.toolbar.active_multi = range_tool
+    if isinstance(range_tool, GestureTool):
+        rng_select.toolbar.active_multi = range_tool
     return rng_select
 
 

--- a/msticpy/vis/timeline_common.py
+++ b/msticpy/vis/timeline_common.py
@@ -15,6 +15,7 @@ from bokeh.models import (  # type: ignore[attr-defined]
     LayoutDOM,
     Range,
     RangeTool,
+    GestureTool,
     Title,
 )
 
@@ -308,7 +309,8 @@ def create_range_tool(
     range_tool.overlay.fill_alpha = 0.2  # type: ignore
     rng_select.ygrid.grid_line_color = None
     rng_select.add_tools(range_tool)
-    rng_select.toolbar.active_multi = range_tool  # type: ignore
+    if isinstance(range_tool, GestureTool):
+        rng_select.toolbar.active_multi = range_tool  # type: ignore
     return rng_select
 
 

--- a/msticpy/vis/timeline_common.py
+++ b/msticpy/vis/timeline_common.py
@@ -415,9 +415,9 @@ def get_tick_formatter() -> DatetimeTickFormatter:
     """Return tick formatting for different zoom levels."""
     # '%H:%M:%S.%3Nms
     tick_format = DatetimeTickFormatter()
-    tick_format.days = ["%m-%d %H:%M"]  # type: ignore
-    tick_format.hours = ["%H:%M:%S"]  # type: ignore
-    tick_format.minutes = ["%H:%M:%S"]  # type: ignore
-    tick_format.seconds = ["%H:%M:%S"]  # type: ignore
-    tick_format.milliseconds = ["%H:%M:%S.%3N"]  # type: ignore
+    tick_format.days = "%m-%d %H:%M"  # type: ignore
+    tick_format.hours = "%H:%M:%S"  # type: ignore
+    tick_format.minutes = "%H:%M:%S"  # type: ignore
+    tick_format.seconds = "%H:%M:%S"  # type: ignore
+    tick_format.milliseconds = "%H:%M:%S.%3N"  # type: ignore
     return tick_format

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -13,7 +13,7 @@ azure-mgmt-resourcegraph>=8.0.0
 azure-mgmt-subscription>=3.0.0
 azure-storage-blob>=12.5.0
 beautifulsoup4>=4.0.0
-bokeh>=1.4.0, <=3.0.2
+bokeh>=1.4.0, <=3.1.0
 cryptography>=3.1
 deprecated>=1.2.4
 dnspython>=2.0.0, <3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ azure-core>=1.24.0
 azure-identity>=1.10.0
 azure-mgmt-subscription>=3.0.0
 beautifulsoup4>=4.0.0
-bokeh>=1.4.0, <=3.0.2
+bokeh>=1.4.0, <=3.1.0
 cryptography>=3.1
 deprecated>=1.2.4
 dnspython>=2.0.0, <3.0.0


### PR DESCRIPTION
Addressing an issue when activating a RangeTool when using Bokeh.  Version 3.1.0 Bokeh introduced breaking changes when activating RangeTool. 

Reference Link:
https://github.com/bokeh/bokeh/wiki/Migration-Guides

_RangeTool is not a multi GestureTool anymore, thus it can't be activated with Toolbar.active_multi. The tool is now active by default._

Fix:
Adding check if RangeTool is a GestureTool (for backward compatibility) and only then activate the tool. Otherwise on Bokeh 3.1.0 the tool is active by default.
