### PR TITLE
Reverting to bokeh version 2.4.3 for default install

### DIFF
--- a/conda/conda-reqs.txt
+++ b/conda/conda-reqs.txt
@@ -10,7 +10,7 @@ azure-mgmt-network>=2.7.0
 azure-mgmt-resource>=16.1.0
 azure-storage-blob>=12.5.0
 beautifulsoup4>=4.0.0
-bokeh>=1.4.0, <=3.1.0
+bokeh>=1.4.0, <=2.4.3
 cryptography>=3.1
 deprecated>=1.2.4
 dnspython>=2.0.0, <3.0.0

--- a/msticpy/vis/process_tree.py
+++ b/msticpy/vis/process_tree.py
@@ -361,6 +361,9 @@ def _pre_process_tree(
 
     _validate_plot_schema(proc_tree, schema)
 
+    # kludgy fix to prevent NaNs making it into the data - Bokeh 3.0
+    # is very sensitive to this in some places.
+    proc_tree = proc_tree.fillna("NA")
     proc_tree = proc_tree.sort_values(
         by=["path", schema.time_stamp], ascending=True
     ).reset_index()
@@ -400,12 +403,25 @@ def _pre_process_tree(
 
 
 def _pid_fmt(pid, pid_fmt):
+    """Format process ID in required string format."""
+    if pid == np.nan:
+        pid = ""
     if pid_fmt == "hex":
-        return f"PID: {pid}" if str(pid).startswith("0x") else f"PID: 0x{int(pid):x}"
+        return (
+            f"PID: {pid}"
+            if str(pid).startswith("0x")
+            else f"PID: 0x{int(pid):x}"
+            if isinstance(pid, int)
+            else "NA"
+        )
     if pid_fmt == "guid":
         return f"GUID: {pid}"
     return (
-        f"PID: {pid}" if not str(pid).startswith("0x") else f"PID: {int(pid, base=16)}"
+        f"PID: {pid}"
+        if not str(pid).startswith("0x")
+        else f"PID: {int(pid, base=16)}"
+        if isinstance(pid, int)
+        else "NA"
     )
 
 

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -13,7 +13,7 @@ azure-mgmt-resourcegraph>=8.0.0
 azure-mgmt-subscription>=3.0.0
 azure-storage-blob>=12.5.0
 beautifulsoup4>=4.0.0
-bokeh>=1.4.0, <=3.1.0
+bokeh>=1.4.0, <=2.4.3
 cryptography>=3.1
 deprecated>=1.2.4
 dnspython>=2.0.0, <3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ azure-core>=1.24.0
 azure-identity>=1.10.0
 azure-mgmt-subscription>=3.0.0
 beautifulsoup4>=4.0.0
-bokeh>=1.4.0, <=3.1.0
+bokeh>=1.4.0, <=2.4.3
 cryptography>=3.1
 deprecated>=1.2.4
 dnspython>=2.0.0, <3.0.0


### PR DESCRIPTION
Replacing NAs in process_tree DF - causes Bokeh 3.0 to fail