### PR TITLE
Added additional DataProvider for Advanced Hunting via Graph

### DIFF
--- a/msticpy/data/core/query_defns.py
+++ b/msticpy/data/core/query_defns.py
@@ -96,7 +96,7 @@ class DataEnvironment(Enum):
     Kusto_New = 2  # alias of Kusto
     MSGraph = 4
     SecurityGraph = 4
-    GraphHunting = 5
+
     MDE = 5
     MDATP = 5  # alias of MDE
     LocalData = 6
@@ -116,6 +116,7 @@ class DataEnvironment(Enum):
     Kusto_KQLM = 17
     VelociraptorLogs = 18
     Velociraptor = 18
+    M365DGraph = 20
 
     @classmethod
     def parse(cls, value: Union[str, int]) -> "DataEnvironment":

--- a/msticpy/data/core/query_defns.py
+++ b/msticpy/data/core/query_defns.py
@@ -96,6 +96,7 @@ class DataEnvironment(Enum):
     Kusto_New = 2  # alias of Kusto
     MSGraph = 4
     SecurityGraph = 4
+    GraphHunting = 5
     MDE = 5
     MDATP = 5  # alias of MDE
     LocalData = 6

--- a/msticpy/data/drivers/__init__.py
+++ b/msticpy/data/drivers/__init__.py
@@ -39,6 +39,7 @@ _ENVIRONMENT_DRIVERS = {
     ),
     DataEnvironment.MSSentinel_Legacy: ("kql_driver", "KqlDriver"),
     DataEnvironment.Kusto_Legacy: ("kusto_driver", "KustoDriver"),
+    DataEnvironment.GraphHunting: ("mdatp_driver", "MDATPDriver")
 }
 
 CUSTOM_PROVIDERS: Dict[str, type] = {}

--- a/msticpy/data/drivers/__init__.py
+++ b/msticpy/data/drivers/__init__.py
@@ -39,7 +39,7 @@ _ENVIRONMENT_DRIVERS = {
     ),
     DataEnvironment.MSSentinel_Legacy: ("kql_driver", "KqlDriver"),
     DataEnvironment.Kusto_Legacy: ("kusto_driver", "KustoDriver"),
-    DataEnvironment.GraphHunting: ("mdatp_driver", "MDATPDriver")
+    DataEnvironment.M365DGraph: ("mdatp_driver", "MDATPDriver"),
 }
 
 CUSTOM_PROVIDERS: Dict[str, type] = {}

--- a/msticpy/data/drivers/odata_driver.py
+++ b/msticpy/data/drivers/odata_driver.py
@@ -277,7 +277,8 @@ class OData(DriverBase):
             )
             return None, json_response  # type: ignore
 
-        result = json_response.get("Results", json_response)
+        results_key = "Results" if "Results" in json_response else "results"
+        result = json_response.get(results_key, json_response)
 
         if not result:
             print("Warning - query did not return any results.")


### PR DESCRIPTION
Added changes to the MDATP driver to differentiate between legacy hunting and the newer Graph hunting queries: https://learn.microsoft.com/en-us/graph/api/security-security-runhuntingquery?view=graph-rest-1.0

Not sure how long the 'older' version will still be supported but the original documentation (https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/api/run-advanced-query-api?view=o365-worldwide) mentions that the newer Graph version supports more tables/features :) 