### PR TITLE
Allow POST HTTP method

### DIFF
--- a/msticpy/context/tiproviders/ti_http_provider.py
+++ b/msticpy/context/tiproviders/ti_http_provider.py
@@ -87,6 +87,10 @@ class HttpTIProvider(TIProvider, HttpProvider):
                 response = self._httpx_client.get(
                     **req_params, timeout=get_http_timeout(**kwargs)
                 )
+            elif verb == "POST":
+                response = self._httpx_client.post(
+                    **req_params, timeout=get_http_timeout(**kwargs)
+                )
             else:
                 raise NotImplementedError(f"Unsupported verb {verb}")
 


### PR DESCRIPTION
Some TI providers need `POST` verb:
- https://www.onyphe.io/docs/apis/bulk_simple_best 
- https://search.censys.io/api#/
- https://api.intelligence.fireeye.com/docs#search
- https://docs.opencti.io/latest/deployment/integrations/#python-library (graphql)

Accepting POST method allow the use of `APILookupParams` instead of implement `lookup_ioc` just to use `POST`