### PR TITLE
Fix time span values

### DIFF
--- a/msticpy/data/drivers/azure_monitor_driver.py
+++ b/msticpy/data/drivers/azure_monitor_driver.py
@@ -477,11 +477,9 @@ class AzureMonitorDriver(DriverBase):
         """Return the timespan for the query API call."""
         default_time_params = kwargs.get("default_time_params", False)
         time_params = kwargs.get("time_span", {})
-        if (
-            default_time_params
-            or "start" not in time_params
-            or "end" not in time_params
-        ):
+        start = time_params.get("start")
+        end = time_params.get("end")
+        if default_time_params or start is None or end is None:
             time_span_value = None
             logger.info("No time parameters supplied.")
         else:


### PR DESCRIPTION
This PR has been created to fix a bug in the function *_get_time_span_value* from _msticpy/data/drivers/azure_monitor_driver.py_.
The issue is related to the way the time_span key is configured:
in _msticpy/data/core/data_providers.py_, function *_get_query_options*:
```
  query_options["time_span"] = {
      "start": params.get("start"),
      "end": params.get("end"),
  }
```
If start or end are not in the dictionary "params", the value returned would be "None", hence time_span would be defined as:
{"start": None, "end": None}.

This is what happens when calling a query that does not have these parameters defined, for instance get_alert in msticpy/data/queries/mssentinel/kql_sent_alert.yaml

The proposed fixed is to check for the value associated with those keys (if defined) in time_span rather than simply checking if the keys are present.