### PR TITLE
Remove stack trace from logging

### DIFF
--- a/msticpy/data/core/query_provider_connections_mixin.py
+++ b/msticpy/data/core/query_provider_connections_mixin.py
@@ -351,7 +351,8 @@ class QueryProviderConnectionsMixin(QueryProviderProtocol):
                     results.append(result)
                 except Exception:  # pylint: disable=broad-except
                     logger.warning(
-                        "Query task '%s' failed with exception", query_id, exc_info=True
+                        "Query task '%s' failed with exception",
+                        query_id,
                     )
                     failed_tasks[query_id] = thread_task
 

--- a/msticpy/data/drivers/azure_kusto_driver.py
+++ b/msticpy/data/drivers/azure_kusto_driver.py
@@ -446,10 +446,10 @@ class AzureKustoDriver(DriverBase):
             status = _parse_query_status(response)
             logger.info("Query completed: %s", str(status))
         except KustoApiError as err:
-            logger.exception("Query failed: %s", err)
+            logger.error("Query failed: %s", err)
             _raise_kusto_error(err)
         except KustoServiceError as err:
-            logger.exception("Query failed: %s", err)
+            logger.error("Query failed: %s", err)
             _raise_unknown_query_error(err)
         return data, status
 


### PR DESCRIPTION
Update logging parameters/method in order for the stack trace not to be included in case of error and ensure clients can have "more readable" output when handling the exception.