### PR TITLE
Add nest_asyncio to run threaded queries

### DIFF
--- a/msticpy/data/core/query_provider_connections_mixin.py
+++ b/msticpy/data/core/query_provider_connections_mixin.py
@@ -12,8 +12,11 @@ from functools import partial
 from itertools import tee
 from typing import Any, Dict, List, Optional, Protocol, Tuple, Union
 
+import nest_asyncio
 import pandas as pd
 from tqdm.auto import tqdm
+
+from msticpy.common.utility.ipython import is_ipython
 
 from ..._version import VERSION
 from ...common.exceptions import MsticpyDataQueryError
@@ -154,6 +157,8 @@ class QueryProviderConnectionsMixin(QueryProviderProtocol):
         # Run the queries threaded if supported
         if self._query_provider.get_driver_property(DriverProps.SUPPORTS_THREADING):
             logger.info("Running threaded queries.")
+            if is_ipython():
+                nest_asyncio.apply()
             event_loop = _get_event_loop()
             return event_loop.run_until_complete(
                 self._exec_queries_threaded(query_tasks, progress, retry)
@@ -233,6 +238,8 @@ class QueryProviderConnectionsMixin(QueryProviderProtocol):
         # Run the queries threaded if supported
         if self._query_provider.get_driver_property(DriverProps.SUPPORTS_THREADING):
             logger.info("Running threaded queries.")
+            if is_ipython():
+                nest_asyncio.apply()
             event_loop = _get_event_loop()
             return event_loop.run_until_complete(
                 self._exec_queries_threaded(query_tasks, progress, retry)

--- a/msticpy/data/core/query_provider_connections_mixin.py
+++ b/msticpy/data/core/query_provider_connections_mixin.py
@@ -157,8 +157,6 @@ class QueryProviderConnectionsMixin(QueryProviderProtocol):
         # Run the queries threaded if supported
         if self._query_provider.get_driver_property(DriverProps.SUPPORTS_THREADING):
             logger.info("Running threaded queries.")
-            if is_ipython():
-                nest_asyncio.apply()
             event_loop = _get_event_loop()
             return event_loop.run_until_complete(
                 self._exec_queries_threaded(query_tasks, progress, retry)
@@ -384,6 +382,8 @@ class QueryProviderConnectionsMixin(QueryProviderProtocol):
 def _get_event_loop() -> asyncio.AbstractEventLoop:
     """Return the current event loop, or create a new one."""
     try:
+        if is_ipython():
+            nest_asyncio.apply()
         loop = asyncio.get_running_loop()
     except RuntimeError:
         loop = asyncio.new_event_loop()

--- a/msticpy/data/core/query_provider_connections_mixin.py
+++ b/msticpy/data/core/query_provider_connections_mixin.py
@@ -236,8 +236,6 @@ class QueryProviderConnectionsMixin(QueryProviderProtocol):
         # Run the queries threaded if supported
         if self._query_provider.get_driver_property(DriverProps.SUPPORTS_THREADING):
             logger.info("Running threaded queries.")
-            if is_ipython():
-                nest_asyncio.apply()
             event_loop = _get_event_loop()
             return event_loop.run_until_complete(
                 self._exec_queries_threaded(query_tasks, progress, retry)

--- a/msticpy/data/core/query_provider_connections_mixin.py
+++ b/msticpy/data/core/query_provider_connections_mixin.py
@@ -16,10 +16,10 @@ import nest_asyncio
 import pandas as pd
 from tqdm.auto import tqdm
 
-from msticpy.common.utility.ipython import is_ipython
 
 from ..._version import VERSION
 from ...common.exceptions import MsticpyDataQueryError
+from ...common.utility.ipython import is_ipython
 from ..drivers.driver_base import DriverBase, DriverProps
 from .query_source import QuerySource
 


### PR DESCRIPTION
When running queries from a Jupyter notebook, threaded queries do no work unless nest_syncio.apply() is called.

To prevent users having to import this and invoke nest_asyncio.apply() in all their notebooks, this has been done within `msticpy/data/core/query_provider_connections_mixin.py`

This was already used in a few notebooks and for TI Lookup:
* docs/notebooks/ContiLeaksAnalysis.ipynb
* docs/notebooks/VTLookupV3.ipynb
* msticpy/context/lookup.py
* msticpy/context/vtlookupv3/vtlookupv3.py

Reference: https://bugs.python.org/issue22239