### PR TITLE
Added M365DGraph to the supported environments for existing queries

### DIFF
--- a/msticpy/data/queries/m365d/kql_m365_alerts.yaml
+++ b/msticpy/data/queries/m365d/kql_m365_alerts.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1
   description: M365D Queries
-  data_environments: [MDATP, MDE, M365D, LogAnalytics]
+  data_environments: [MDATP, MDE, M365D, M365DGraph, LogAnalytics]
   data_families: [M365D]
   tags: ["alert"]
 defaults:

--- a/msticpy/data/queries/m365d/kql_m365_file.yaml
+++ b/msticpy/data/queries/m365d/kql_m365_file.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1
   description: M365D Queries
-  data_environments: [MDATP, MDE, M365D, LogAnalytics]
+  data_environments: [MDATP, MDE, M365D, M365DGraph, LogAnalytics]
   data_families: [M365D]
   tags: ["file", "process"]
 defaults:

--- a/msticpy/data/queries/m365d/kql_m365_hunting.yaml
+++ b/msticpy/data/queries/m365d/kql_m365_hunting.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1
   description: MDATP Queries
-  data_environments: [MDATP, MDE, M365D, LogAnalytics]
+  data_environments: [MDATP, MDE, M365D, M365DGraph, LogAnalytics]
   data_families: [MDEHunting, M365DHunting]
   tags: ['user']
 defaults:

--- a/msticpy/data/queries/m365d/kql_m365_identity.yaml
+++ b/msticpy/data/queries/m365d/kql_m365_identity.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1
   description: M365D User Queries
-  data_environments: [MDATP, MDE, M365D, LogAnalytics]
+  data_environments: [MDATP, MDE, M365D, M365DGraph, LogAnalytics]
   data_families: [IdentityOnPrem]
   tags: ["user", "account"]
 defaults:

--- a/msticpy/data/queries/m365d/kql_m365_network.yaml
+++ b/msticpy/data/queries/m365d/kql_m365_network.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1
   description: M365D Network Queries
-  data_environments: [MDATP, MDE, M365D, LogAnalytics]
+  data_environments: [MDATP, MDE, M365D, M365DGraph, LogAnalytics]
   data_families: [M365D]
   tags: ["network"]
 defaults:

--- a/msticpy/data/queries/m365d/kql_m365_process.yaml
+++ b/msticpy/data/queries/m365d/kql_m365_process.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1
   description: M365D Process Queries
-  data_environments: [MDATP, MDE, M365D, LogAnalytics]
+  data_environments: [MDATP, MDE, M365D, M365DGraph, LogAnalytics]
   data_families: [M365D]
   tags: ["process"]
 defaults:

--- a/msticpy/data/queries/m365d/kql_m365_user.yaml
+++ b/msticpy/data/queries/m365d/kql_m365_user.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1
   description: M365D User Queries
-  data_environments: [MDATP, MDE, M365D, LogAnalytics]
+  data_environments: [MDATP, MDE, M365D, M365DGraph, LogAnalytics]
   data_families: [M365D]
   tags: ["user", "account"]
 defaults:


### PR DESCRIPTION
Added the new Graph-based provider (M365DGraph) to the list of supported data_environments for the existing M365D queries since queries/kql are identical :) 