### PR TITLE
Fixing group.apply for pandas < 2.2.1

### DIFF
--- a/msticpy/analysis/anomalous_sequence/sessionize.py
+++ b/msticpy/analysis/anomalous_sequence/sessionize.py
@@ -12,6 +12,9 @@ import pandas as pd
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
 # mypy: ignore-errors
+_PD_VERSION = tuple(int(v) for v in pd.__version__.split("."))
+if _PD_VERSION >= (2, 2, 0):
+    pd.set_option("future.no_silent_downcasting", True)
 
 
 def sessionize_data(
@@ -97,7 +100,6 @@ def sessionize_data(
         agg_df = agg_df.drop("index", axis=1)
 
     # replace dummy_str with nan values
-    pd.set_option("future.no_silent_downcasting", True)
     for col in user_identifier_cols:
         agg_df[col] = agg_df[col].replace("dummy_str", np.nan)
 
@@ -199,7 +201,6 @@ def create_session_col(
             df_with_sesind.loc[i, "session_ind"] = ses_ind
 
     # replace dummy_str with nan values
-    pd.set_option("future.no_silent_downcasting", True)
     for col in user_identifier_cols:
         df_with_sesind[col] = df_with_sesind[col].replace("dummy_str", np.nan)
 

--- a/msticpy/analysis/polling_detection.py
+++ b/msticpy/analysis/polling_detection.py
@@ -23,6 +23,12 @@ from scipy import signal, special
 
 from ..common.utility import export
 
+_PD_VERSION = tuple(int(v) for v in pd.__version__.split("."))
+if _PD_VERSION <= (2, 2, 1):
+    GROUP_APPLY_PARAMS = {"include_groups": False}
+else:
+    GROUP_APPLY_PARAMS = {}
+
 
 @export
 class PeriodogramPollingDetector:
@@ -212,7 +218,7 @@ class PeriodogramPollingDetector:
                 lambda x: self._detect_polling_arr(  # type: ignore
                     x[time_column], min(x[time_column]), max(x[time_column])  # type: ignore
                 ),
-                include_groups=False,
+                **GROUP_APPLY_PARAMS,
             )
 
             grouped_results_df = pd.DataFrame(

--- a/msticpy/analysis/polling_detection.py
+++ b/msticpy/analysis/polling_detection.py
@@ -24,7 +24,7 @@ from scipy import signal, special
 from ..common.utility import export
 
 _PD_VERSION = tuple(int(v) for v in pd.__version__.split("."))
-if _PD_VERSION <= (2, 2, 1):
+if _PD_VERSION >= (2, 2, 1):
     GROUP_APPLY_PARAMS = {"include_groups": False}
 else:
     GROUP_APPLY_PARAMS = {}


### PR DESCRIPTION
include_groups parameter required by PD 3.0 deprecation not supported in pandas < 2.2.1 and Python 3.8