### PR TITLE
Fix split query time-ranges calculation

### DIFF
--- a/msticpy/data/core/query_provider_connections_mixin.py
+++ b/msticpy/data/core/query_provider_connections_mixin.py
@@ -410,14 +410,14 @@ def _calc_split_ranges(start: datetime, end: datetime, split_delta: pd.Timedelta
     # Since the generated time ranges are based on deltas from 'start'
     # we need to adjust the end time on the final range.
     # If the difference between the calculated last range end and
-    # the query 'end' that the user requested is small (< 10% of a delta),
+    # the query 'end' that the user requested is small (< 0.1% of a delta),
     # we just replace the last "end" time with our query end time.
-    if (ranges[-1][1] - end) < (split_delta / 10):
-        ranges[-1] = ranges[-1][0], end
+    if (end - ranges[-1][1]) < (split_delta / 1000):
+        ranges[-1] = ranges[-1][0], pd.Timestamp(end)
     else:
         # otherwise append a new range starting after the last range
         # in ranges and ending in 'end"
         # note - we need to add back our subtracted 1 nanosecond
-        ranges.append((ranges[-1][0] + pd.Timedelta("1ns"), end))
+        ranges.append((ranges[-1][1] + pd.Timedelta("1ns"), pd.Timestamp(end)))
 
     return ranges

--- a/msticpy/data/drivers/azure_monitor_driver.py
+++ b/msticpy/data/drivers/azure_monitor_driver.py
@@ -322,7 +322,9 @@ class AzureMonitorDriver(DriverBase):
                 help_uri=_HELP_URL,
             )
         time_span_value = self._get_time_span_value(**kwargs)
-        fail_on_partial = kwargs.get("fail_if_partial", False)
+        fail_on_partial = kwargs.get(
+            "fail_if_partial", kwargs.get("fail_on_partial", False)
+        )
         server_timeout = kwargs.pop("timeout", self._def_timeout)
 
         workspace_id = next(iter(self._workspace_ids), None) or self._workspace_id

--- a/tests/data/test_async_queries.py
+++ b/tests/data/test_async_queries.py
@@ -104,7 +104,7 @@ def test_split_queries_sync():
         "print", host_name="DESKTOP-12345", start=start, end=end, split_query_by="1H"
     )
     queries = result_queries.split("\n\n")
-    check.equal(len(queries), 5)
+    check.equal(len(queries), 6)
 
     for idx, (st_time, e_time) in enumerate(ranges):
         check.is_in(st_time.isoformat(sep=" "), queries[idx])
@@ -119,7 +119,7 @@ def test_split_queries_sync():
         host_name="DESKTOP-12345", start=start, end=end, split_query_by="1H"
     )
     # verify len of result is 2x single_result
-    check.equal(single_results.shape[0] * 5, result_queries.shape[0])
+    check.equal(single_results.shape[0] * 6, result_queries.shape[0])
     # verify columns/schema is the same.
     check.equal(list(single_results.columns), list(result_queries.columns))
 
@@ -144,7 +144,7 @@ def test_split_queries_async():
         "print", host_name="DESKTOP-12345", start=start, end=end, split_query_by="1H"
     )
     queries = result_queries.split("\n\n")
-    check.equal(len(queries), 5)
+    check.equal(len(queries), 6)
 
     for idx, (st_time, e_time) in enumerate(ranges):
         check.is_in(st_time.isoformat(sep=" "), queries[idx])
@@ -159,6 +159,6 @@ def test_split_queries_async():
         host_name="DESKTOP-12345", start=start, end=end, split_query_by="1H"
     )
     # verify len of result is 2x single_result
-    check.equal(single_results.shape[0] * 5, result_queries.shape[0])
+    check.equal(single_results.shape[0] * 6, result_queries.shape[0])
     # verify columns/schema is the same.
     check.equal(list(single_results.columns), list(result_queries.columns))

--- a/tests/data/test_dataqueries.py
+++ b/tests/data/test_dataqueries.py
@@ -359,7 +359,7 @@ class TestDataQuery(unittest.TestCase):
         delta = pd.Timedelta("1h")
 
         ranges = _calc_split_ranges(start, end, delta)
-        self.assertEqual(len(ranges), 5)
+        self.assertEqual(len(ranges), 6)
         self.assertEqual(ranges[0][0], start)
         self.assertEqual(ranges[-1][1], end)
 
@@ -369,7 +369,7 @@ class TestDataQuery(unittest.TestCase):
 
         end = end + pd.Timedelta("20min")
         ranges = _calc_split_ranges(start, end, delta)
-        self.assertEqual(len(ranges), 5)
+        self.assertEqual(len(ranges), 6)
         self.assertEqual(ranges[0][0], start)
         self.assertEqual(ranges[-1][1], end)
 
@@ -386,7 +386,7 @@ class TestDataQuery(unittest.TestCase):
             "print", start=start, end=end, split_query_by="1H"
         )
         queries = result_queries.split("\n\n")
-        self.assertEqual(len(queries), 5)
+        self.assertEqual(len(queries), 6)
 
         for idx, (st_time, e_time) in enumerate(ranges):
             self.assertIn(st_time.isoformat(sep="T") + "Z", queries[idx])
@@ -416,7 +416,7 @@ class TestDataQuery(unittest.TestCase):
             "print", start=start, end=end, split_query_by="Invalid"
         )
         queries = result_queries.split("\n\n")
-        self.assertEqual(len(queries), 5)
+        self.assertEqual(len(queries), 6)
 
 
 _LOCAL_DATA_PATHS = [str(get_test_data_path().joinpath("localdata"))]


### PR DESCRIPTION
@pjain90 provided a fix for the calculation logic in issue #761

Also in here is a correction to handle split query fail parameter `fail_on_partial` (this parameter was documented as `fail_on_partial` but the implementation was looking for `fail_if_partial` - both parameters are now supported).