### PR TITLE
Pass `true` for props into `_build_sent_data` when calling `update_incident`

### DIFF
--- a/msticpy/context/azure/sentinel_incidents.py
+++ b/msticpy/context/azure/sentinel_incidents.py
@@ -249,7 +249,7 @@ class SentinelIncidentsMixin:
             update_items["title"] = incident_dets.iloc[0]["properties.title"]
         if "status" not in update_items.keys():
             update_items["status"] = incident_dets.iloc[0]["properties.status"]
-        data = _build_sent_data(update_items, etag=incident_dets.iloc[0]["etag"])
+        data = _build_sent_data(update_items, props=true, etag=incident_dets.iloc[0]["etag"])
         response = httpx.put(
             incident_url,
             headers=get_api_headers(self._token),  # type: ignore

--- a/msticpy/context/azure/sentinel_incidents.py
+++ b/msticpy/context/azure/sentinel_incidents.py
@@ -249,7 +249,7 @@ class SentinelIncidentsMixin:
             update_items["title"] = incident_dets.iloc[0]["properties.title"]
         if "status" not in update_items.keys():
             update_items["status"] = incident_dets.iloc[0]["properties.status"]
-        data = _build_sent_data(update_items, props=true, etag=incident_dets.iloc[0]["etag"])
+        data = _build_sent_data(update_items, props=True, etag=incident_dets.iloc[0]["etag"])
         response = httpx.put(
             incident_url,
             headers=get_api_headers(self._token),  # type: ignore

--- a/msticpy/context/azure/sentinel_incidents.py
+++ b/msticpy/context/azure/sentinel_incidents.py
@@ -249,7 +249,9 @@ class SentinelIncidentsMixin:
             update_items["title"] = incident_dets.iloc[0]["properties.title"]
         if "status" not in update_items.keys():
             update_items["status"] = incident_dets.iloc[0]["properties.status"]
-        data = _build_sent_data(update_items, props=True, etag=incident_dets.iloc[0]["etag"])
+        data = _build_sent_data(
+            update_items, props=True, etag=incident_dets.iloc[0]["etag"]
+        )
         response = httpx.put(
             incident_url,
             headers=get_api_headers(self._token),  # type: ignore

--- a/msticpy/context/azure/sentinel_utils.py
+++ b/msticpy/context/azure/sentinel_utils.py
@@ -276,7 +276,7 @@ def _build_sent_data(items: dict, props: bool = False, **kwargs) -> dict:
     """
     data_body = {"properties": {}}  # type: Dict[str, Dict[str, str]]
     for key in items:
-        if key in ["severity", "status", "title", "message", "searchResults"] or props:
+        if key in ["severity", "status", "title", "message", "searchResults", "labels"] or props:
             data_body["properties"].update({key: items[key]})  # type:ignore
         else:
             data_body[key] = items[key]

--- a/msticpy/context/azure/sentinel_utils.py
+++ b/msticpy/context/azure/sentinel_utils.py
@@ -276,7 +276,7 @@ def _build_sent_data(items: dict, props: bool = False, **kwargs) -> dict:
     """
     data_body = {"properties": {}}  # type: Dict[str, Dict[str, str]]
     for key in items:
-        if key in ["severity", "status", "title", "message", "searchResults", "labels"] or props:
+        if key in ["severity", "status", "title", "message", "searchResults"] or props:
             data_body["properties"].update({key: items[key]})  # type:ignore
         else:
             data_body[key] = items[key]


### PR DESCRIPTION
This PR updates the `update_incident` function to pass `true` for the `props` parameter of `_build_sent_data`. 

This helps us solve the use case of being able to pass in an object like `{'labels': [{'labelName': 'test', 'labelType': 'User'}]}` when calling `update_incident` . 

This should allow `labels` to be passed in according to the documentation here: https://learn.microsoft.com/en-us/rest/api/securityinsights/incidents/create-or-update?view=rest-securityinsights-2024-03-01&tabs=HTTP

We have tried doing something like `update_incident(incident_id='xxx', update_items={'severity': 'xxx', 'properties.labels': [{'labelName': 'test", 'labelType': 'User'}])` with no luck