### PR TITLE
Fixing np.NaN error and build warnings

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,13 +29,13 @@ jobs:
           JOB_CONTEXT: ${{ toJSON(job) }}
         run: echo "$JOB_CONTEXT"
       # end print details
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -96,13 +96,13 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -126,15 +126,15 @@ jobs:
     permissions: read-all
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -174,11 +174,11 @@ jobs:
         if: ${{ always() }}
       - name: pylint
         run: |
-          pylint msticpy --disable=duplicate-code --disable=E1135,E1101,E1133
+          pylint msticpy --disable=duplicate-code --disable=E1135,E1101,E1133,W0101
         if: ${{ always() }}
       - name: Cache/restore MyPy data
         id: cache-mypy
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # MyPy cache files are stored in `~/.mypy_cache`
           path: .mypy_cache

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -79,7 +79,9 @@ jobs:
           IPSTACK_AUTH: ${{ secrets.IPSTACK_AUTH }}
           MSTICPYCONFIG: ./tests/msticpyconfig-test.yaml
           MSTICPY_BUILD_SOURCE: fork
+          JUPYTER_PLATFORM_DIRS: 1
         run: |
+          jupyter --paths
           pytest tests -n auto --junitxml=junit/test-${{ matrix.python-version }}-results.xml --cov=msticpy --cov-report=xml
         if: ${{ always() }}
       - name: Upload pytest test results

--- a/msticpy/analysis/eventcluster.py
+++ b/msticpy/analysis/eventcluster.py
@@ -679,7 +679,7 @@ def plot_cluster(  # noqa: C901, MC0001
         raise ValueError(mssg + f" {max_idx}.")
 
     labels = db_cluster.labels_
-    core_samples_mask = np.zeros_like(labels, dtype=bool)
+    core_samples_mask: np.ndarray = np.zeros_like(labels, dtype=bool)
 
     # pylint: disable=unsupported-assignment-operation
     # (assignment of numpy array is valid)

--- a/msticpy/analysis/eventcluster.py
+++ b/msticpy/analysis/eventcluster.py
@@ -39,6 +39,7 @@ from typing import Any, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 
 from .._version import VERSION
 from ..common.exceptions import MsticpyImportExtraError
@@ -679,7 +680,7 @@ def plot_cluster(  # noqa: C901, MC0001
         raise ValueError(mssg + f" {max_idx}.")
 
     labels = db_cluster.labels_
-    core_samples_mask: np.ndarray = np.zeros_like(labels, dtype=bool)
+    core_samples_mask: NDArray[np.bool_] = np.zeros_like(labels, dtype=bool)
 
     # pylint: disable=unsupported-assignment-operation
     # (assignment of numpy array is valid)

--- a/msticpy/config/query_editor.py
+++ b/msticpy/config/query_editor.py
@@ -126,8 +126,8 @@ def box_layout():
             border="1px solid black",
             margin="5px",
             padding="5px",
-            style={"padding": "5px", "background-color": "red"},
-        )
+        ),
+        # "style": {"padding": "5px", "background-color": "red"}
     }
 
 
@@ -170,7 +170,7 @@ class QueryParameterEditWidget(IPyDisplayMixin):
         self.param_container = container
         self.parameter_dropdown = widgets.Select(
             description="Parameters",
-            size=5,
+            rows=5,
             options=list(
                 self.param_container.parameters.keys()
                 if self.param_container.parameters

--- a/msticpy/context/vtlookupv3/vtfile_behavior.py
+++ b/msticpy/context/vtlookupv3/vtfile_behavior.py
@@ -380,6 +380,7 @@ def _try_match_commandlines(
     """Return DF with matched commandlines."""
     procs_cmd = procs_cmds.copy()
     procs_cmd["cmd_line"] = np.nan
+    procs_cmd["cmd_line"] = procs_cmd["cmd_line"].astype(object)  # Set dtype to object
     weak_matches = 0
     for cmd in command_executions:
         for idx, row in procs_cmd.iterrows():
@@ -418,6 +419,7 @@ def _try_match_commandlines(
 def _fill_missing_proc_tree_values(process_df: pd.DataFrame) -> pd.DataFrame:
     # Define a schema to map Df names on to internal ProcSchema
     process_df["path"] = np.nan
+    process_df["path"] = process_df["path"].astype(object)  # Set dtype to object
     process_df.loc[process_df.IsRoot, "path"] = pd.Series(
         process_df[process_df.IsRoot].index.astype("str")
     ).apply(lambda x: x.zfill(5))

--- a/msticpy/vis/entity_graph_tools.py
+++ b/msticpy/vis/entity_graph_tools.py
@@ -335,7 +335,7 @@ class EntityGraph:
             }
             for node in self.alertentity_graph.nodes.values()
         ]
-        return pd.DataFrame(node_list).replace("None", np.NaN)
+        return pd.DataFrame(node_list).replace("None", np.nan)
 
     def _add_incident_or_alert_node(self, incident: Union[Incident, Alert, None]):
         """Check what type of entity is passed in and creates relevant graph."""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,6 +27,7 @@ pylint>=2.5.3
 pyroma>=3.1
 pytest-check>=1.0.1
 pytest-cov>=2.11.1
+pytest-env>=1.1.0
 pytest-xdist>=2.5.0
 pytest>=5.0.1
 readthedocs-sphinx-ext==2.2.5

--- a/tests/common/test_pkg_config.py
+++ b/tests/common/test_pkg_config.py
@@ -22,6 +22,7 @@ from ..unit_test_lib import custom_mp_config, get_test_data_path
 _TEST_DATA = get_test_data_path()
 
 # pylint: disable=protected-access
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 
 def test_load_default():

--- a/tests/config/test_item_editors.py
+++ b/tests/config/test_item_editors.py
@@ -32,6 +32,7 @@ from ..unit_test_lib import TEST_DATA_PATH
 __author__ = "Ian Hellen"
 
 # pylint: disable=redefined-outer-name
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 _KUSTO_DP_INST = {
     "Args": {"Cluster": "https://msticti.kusto.windows.net", "IntegratedAuth": True}

--- a/tests/context/azure/test_azuredata.py
+++ b/tests/context/azure/test_azuredata.py
@@ -21,6 +21,7 @@ from msticpy.context.azure.azure_data import AzureData
 from ...unit_test_lib import custom_mp_config, get_test_data_path
 
 # pylint: disable=protected-access
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 _TEST_DATA = get_test_data_path()
 

--- a/tests/context/azure/test_sentinel_workspaces.py
+++ b/tests/context/azure/test_sentinel_workspaces.py
@@ -17,7 +17,7 @@ from msticpy.context.azure import MicrosoftSentinel
 from msticpy.data import QueryProvider
 
 # pylint: disable=protected-access
-pytestmark = pytest.mark.filterwarnings("ignore::PytestCollectionWarning")
+pytestmark = pytest.mark.filterwarnings("ignore::pytest.PytestCollectionWarning")
 
 _PORTAL_URLS = [
     "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/d1d8779d-38d7-4f06-91db-9cbc8de0176f/resourceGroups/soc/providers/Microsoft.OperationalInsights/workspaces/cybersecuritysoc/Overview",

--- a/tests/context/azure/test_sentinel_workspaces.py
+++ b/tests/context/azure/test_sentinel_workspaces.py
@@ -6,6 +6,7 @@
 """Azure Sentinel unit tests."""
 import re
 from collections import namedtuple
+from dataclasses import dataclass
 
 import pandas as pd
 import pytest
@@ -17,7 +18,6 @@ from msticpy.context.azure import MicrosoftSentinel
 from msticpy.data import QueryProvider
 
 # pylint: disable=protected-access
-pytestmark = pytest.mark.filterwarnings("ignore::pytest.PytestCollectionWarning")
 
 _PORTAL_URLS = [
     "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/d1d8779d-38d7-4f06-91db-9cbc8de0176f/resourceGroups/soc/providers/Microsoft.OperationalInsights/workspaces/cybersecuritysoc/Overview",
@@ -125,7 +125,16 @@ def _get_ws_results(**kwargs):
     return pd.DataFrame(columns=df.columns)
 
 
-TestExpected = namedtuple("TestExpected", "ws_name, sub_id, res_group, ws_id, ten_id")
+@dataclass
+class TestExpected:
+    """Test expected values."""
+
+    ws_name: str = ""
+    sub_id: str = ""
+    res_group: str = ""
+    ws_id: str = ""
+    ten_id: str = ""
+
 
 _TEST_URL_LOOKUP = [
     (

--- a/tests/context/azure/test_sentinel_workspaces.py
+++ b/tests/context/azure/test_sentinel_workspaces.py
@@ -17,6 +17,7 @@ from msticpy.context.azure import MicrosoftSentinel
 from msticpy.data import QueryProvider
 
 # pylint: disable=protected-access
+pytestmark = pytest.mark.filterwarnings("ignore::PytestCollectionWarning")
 
 _PORTAL_URLS = [
     "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/d1d8779d-38d7-4f06-91db-9cbc8de0176f/resourceGroups/soc/providers/Microsoft.OperationalInsights/workspaces/cybersecuritysoc/Overview",

--- a/tests/context/azure/test_sentinel_workspaces.py
+++ b/tests/context/azure/test_sentinel_workspaces.py
@@ -126,7 +126,7 @@ def _get_ws_results(**kwargs):
 
 
 @dataclass
-class TestExpected:
+class ExpectedResult:
     """Test expected values."""
 
     ws_name: str = ""
@@ -139,7 +139,7 @@ class TestExpected:
 _TEST_URL_LOOKUP = [
     (
         _PORTAL_URLS[0],
-        TestExpected(
+        ExpectedResult(
             "cybersecuritysoc",
             "d1d8779d-38d7-4f06-91db-9cbc8de0176f",
             "soc",
@@ -150,7 +150,7 @@ _TEST_URL_LOOKUP = [
     ),
     (
         _PORTAL_URLS[1],
-        TestExpected(
+        ExpectedResult(
             "asihuntomsworkspacev4",
             "40dcc8bf-0478-4f3b-b275-ed0a94f2c013",
             "asihuntomsworkspacerg",
@@ -161,7 +161,7 @@ _TEST_URL_LOOKUP = [
     ),
     (
         _PORTAL_URLS[2],
-        TestExpected(
+        ExpectedResult(
             "aipdstim",
             "d1d8779d-38d7-4f06-91db-9cbc8de0176f",
             "soc-purview",
@@ -172,7 +172,7 @@ _TEST_URL_LOOKUP = [
     ),
     (
         _PORTAL_URLS[3],
-        TestExpected(
+        ExpectedResult(
             "non-existent",
             "d1d8779d-9999-4f06-91db-9cbc8de0176f",
             "soc-na",

--- a/tests/context/test_vtlookupv3.py
+++ b/tests/context/test_vtlookupv3.py
@@ -46,7 +46,6 @@ def create_vt_client(vt_lib) -> VTLookupV3:
     """Test simple lookup of IoC."""
     vt_lib.Client = VTClient
     vt_lib.APIError = VTAPIError
-
     return VTLookupV3()
 
 
@@ -159,22 +158,6 @@ class VTClient:
     def close(self):
         """Close the client connection."""
         return None
-
-
-def test_init_vt_lookup_class():
-    """Test fetching a key from settings."""
-    test_vt_key = "somerandomvalue"
-
-    vt_client = VTLookupV3(vt_key=test_vt_key)
-    check.equal(vt_client._vt_key, test_vt_key)
-
-    try:
-        curr_vt_key = os.environ.get("VIRUSTOTAL_AUTH", "")
-        os.environ["VIRUSTOTAL_AUTH"] = test_vt_key
-        vt_client = VTLookupV3(vt_key=test_vt_key)
-        check.equal(vt_client._vt_key, test_vt_key)
-    finally:
-        os.environ["VIRUSTOTAL_AUTH"] = curr_vt_key
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")

--- a/tests/data/drivers/test_cybereason_driver.py
+++ b/tests/data/drivers/test_cybereason_driver.py
@@ -20,6 +20,7 @@ from ...unit_test_lib import custom_mp_config, get_test_data_path
 
 MP_PATH = str(get_test_data_path().parent.joinpath("msticpyconfig-test.yaml"))
 # pylint: disable=protected-access
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 _CR_RESULT = {
     "data": {

--- a/tests/data/drivers/test_kusto_driver.py
+++ b/tests/data/drivers/test_kusto_driver.py
@@ -19,6 +19,10 @@ from ...unit_test_lib import custom_mp_config, get_test_data_path
 __author__ = "Ian Hellen"
 
 # pylint: disable=redefined-outer-name, protected-access
+pytestmark = [
+    pytest.mark.filterwarnings("ignore::UserWarning"),
+    pytest.mark.filterwarnings("ignore::DeprecationWarning"),
+]
 
 _KUSTO_SETTINGS = """
 DataProviders:

--- a/tests/data/drivers/test_odata_drivers.py
+++ b/tests/data/drivers/test_odata_drivers.py
@@ -27,7 +27,7 @@ except ImportError:
 
 MP_PATH = str(get_test_data_path().parent.joinpath("msticpyconfig-test.yaml"))
 # pylint: disable=protected-access
-
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 _JSON_RESP = {
     "token_type": "Bearer",

--- a/tests/data/drivers/test_splunk_driver.py
+++ b/tests/data/drivers/test_splunk_driver.py
@@ -29,6 +29,7 @@ SPLUNK_RESULTS_PATCH = SplunkDriver.__module__ + ".sp_results"
 
 # pylint: disable=too-many-branches, too-many-return-statements
 # pylint: disable=no-self-use, too-few-public-methods, protected-access
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 
 def cli_connect(**kwargs):

--- a/tests/data/drivers/test_sumologic_driver.py
+++ b/tests/data/drivers/test_sumologic_driver.py
@@ -32,6 +32,7 @@ SUMOLOGIC_SVC = SumologicDriver.__module__ + ".SumoLogic"
 
 # pylint: disable=too-many-branches, too-many-return-statements
 # pylint: disable=no-self-use, too-few-public-methods, protected-access
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 
 def cli_connect(**kwargs):

--- a/tests/data/test_dataqueries.py
+++ b/tests/data/test_dataqueries.py
@@ -23,10 +23,10 @@ from msticpy.common import pkg_config
 from msticpy.common.exceptions import MsticpyException
 from msticpy.data.core.data_providers import QueryProvider
 from msticpy.data.core.query_container import QueryContainer
+from msticpy.data.core.query_defns import DataEnvironment
 from msticpy.data.core.query_provider_connections_mixin import _calc_split_ranges
 from msticpy.data.core.query_source import QuerySource
 from msticpy.data.drivers.driver_base import DriverBase, DriverProps
-from msticpy.data.query_defns import DataEnvironment
 
 from ..unit_test_lib import get_test_data_path
 

--- a/tests/data/test_dataqueries.py
+++ b/tests/data/test_dataqueries.py
@@ -748,7 +748,7 @@ def test_check_environment_unknown_env_type() -> None:
     invalid_data_environment: int = 42
     with pytest.raises(
         TypeError,
-        match=f"Unknown data environment type {invalid_data_environment} \({type(invalid_data_environment)}\)",
+        match=f"Unknown data environment type {invalid_data_environment} \\({type(invalid_data_environment)}\\)",
     ):
         QueryProvider._check_environment(invalid_data_environment)
 

--- a/tests/init/test_mp_plugins.py
+++ b/tests/init/test_mp_plugins.py
@@ -90,6 +90,7 @@ def test_custom_data_provider(load_plugins):
 
 
 # pylint: disable=protected-access
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @respx.mock
 def test_custom_ti_provider(load_plugins):
     """Test TI plugin."""
@@ -116,7 +117,7 @@ def test_custom_ti_provider(load_plugins):
                 }
             ]
         )
-        respx.get(re.compile("https://api\.service\.com/.*")).respond(
+        respx.get(re.compile(r"https://api\.service\.com/.*")).respond(
             200, json=_df_results.iloc[0].to_dict()
         )
 

--- a/tests/vis/test_matrix_plot.py
+++ b/tests/vis/test_matrix_plot.py
@@ -105,6 +105,7 @@ _TEST_PARAMS = [
 ]
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("test_data, exception", _TEST_PARAMS)
 def test_matrix_plot(network_data, test_data, exception):
     """Function_docstring."""

--- a/tests/vis/test_morph_charts.py
+++ b/tests/vis/test_morph_charts.py
@@ -26,6 +26,7 @@ def test_morph():
     return MorphCharts()
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @patch("builtins.print")
 def test_chart_details(mocked_print, test_morph):
     """Test case."""


### PR DESCRIPTION
Fixing pandas deprecation warnings in vtfile_behaviour and process_tree_utils.
The rest is mostly suppressing expected warnings in unit tests