### PR TITLE
Update sentinel_analytics.py to update get_alert_rules to use new API version

### DIFF
--- a/msticpy/context/azure/sentinel_analytics.py
+++ b/msticpy/context/azure/sentinel_analytics.py
@@ -75,7 +75,7 @@ class SentinelAnalyticsMixin:
 
         """
         return self._list_items(  # type: ignore
-            item_type="alert_rules", api_version="2022-11-01"
+            item_type="alert_rules", api_version="2024-01-01-preview"
         )
 
     def _get_template_id(


### PR DESCRIPTION
Update the API version for get_alert_rules to include NRT and newer rule types. 

#788 