### PR TITLE
Fixing azure_monitor_driver for deprecated httpx API

### DIFF
--- a/msticpy/data/drivers/azure_monitor_driver.py
+++ b/msticpy/data/drivers/azure_monitor_driver.py
@@ -24,7 +24,7 @@ import httpx
 import pandas as pd
 from azure.core.exceptions import HttpResponseError
 from azure.core.pipeline.policies import UserAgentPolicy
-from packaging.version import parse as parse_version
+from packaging.version import Version, parse as parse_version
 
 from ..._version import VERSION
 from ...auth.azure_auth import AzureCloudConfig, az_connect
@@ -607,18 +607,19 @@ class AzureMonitorDriver(DriverBase):
         logger.info("Schema request to %s", fmt_url)
 
         # Handle proxies (parameter changes in httpx 0.25.0)
-        httpx_version = parse_version(httpx.__version__)
-        proxies = self._def_proxies or {}
-        httpx_proxy_kwargs = {}
+        httpx_version: Version = parse_version(httpx.__version__)
+        proxies: dict[str, str] = self._def_proxies or {}
+        httpx_proxy_kwargs: dict[str, Any] = {}
         if proxies:
             if httpx_version < parse_version("0.25.0"):
                 httpx_proxy_kwargs = {"proxies": proxies}
             else:
                 httpx_proxy_kwargs = {"mounts": proxies}
         with httpx.Client(
-            timeout=get_http_timeout(), **httpx_proxy_kwargs
+            timeout=get_http_timeout(),
+            **httpx_proxy_kwargs,
         ) as httpx_client:
-            response = httpx_client.get(
+            response: httpx.Response = httpx_client.get(
                 fmt_url,
                 headers=headers,
             )

--- a/msticpy/data/drivers/azure_monitor_driver.py
+++ b/msticpy/data/drivers/azure_monitor_driver.py
@@ -623,7 +623,7 @@ class AzureMonitorDriver(DriverBase):
                 fmt_url,
                 headers=headers,
             )
-        if response.status_code != 200:
+        if response.status_code != httpx.codes.OK:
             logger.info("Schema request failed. Status code: %d", response.status_code)
             return {}
         tables = response.json()

--- a/msticpy/data/drivers/azure_monitor_driver.py
+++ b/msticpy/data/drivers/azure_monitor_driver.py
@@ -605,12 +605,23 @@ class AzureMonitorDriver(DriverBase):
         token = credentials.modern.get_token(f"{mgmt_endpoint}/.default")
         headers = {"Authorization": f"Bearer {token.token}", **mp_ua_header()}
         logger.info("Schema request to %s", fmt_url)
-        response = httpx.get(
-            fmt_url,
-            headers=headers,
-            timeout=get_http_timeout(),
-            proxies=self._def_proxies or {},
-        )
+
+        # Handle proxies (parameter changes in httpx 0.25.0)
+        httpx_version = parse_version(httpx.__version__)
+        proxies = self._def_proxies or {}
+        httpx_proxy_kwargs = {}
+        if proxies:
+            if httpx_version < parse_version("0.25.0"):
+                httpx_proxy_kwargs = {"proxies": proxies}
+            else:
+                httpx_proxy_kwargs = {"mounts": proxies}
+        with httpx.Client(
+            timeout=get_http_timeout(), **httpx_proxy_kwargs
+        ) as httpx_client:
+            response = httpx_client.get(
+                fmt_url,
+                headers=headers,
+            )
         if response.status_code != 200:
             logger.info("Schema request failed. Status code: %d", response.status_code)
             return {}

--- a/msticpy/datamodel/entities/host_logon_session.py
+++ b/msticpy/datamodel/entities/host_logon_session.py
@@ -75,7 +75,7 @@ class HostLogonSession(Entity):
         self.StartTimeUtc: datetime = datetime.min
         self.EndTimeUtc: datetime = datetime.min
         self.Host: Optional[Host] = None
-        self.SessionId: str | None = ""
+        self.SessionId: str | None = None
         super().__init__(src_entity=src_entity, **kwargs)
 
         if src_event is not None:

--- a/msticpy/transform/process_tree_utils.py
+++ b/msticpy/transform/process_tree_utils.py
@@ -423,7 +423,7 @@ def tree_to_text(
     Raises
     ------
     ValueError
-        If neither of
+        If neither schema nor template are supplied as parameters.
 
     """
     if not schema and not template:


### PR DESCRIPTION
httpx has deprecated/removed `proxies` parameter in API call.
Replacing with `mounts` in httpx.Client
Also fixed a doc bug in process_tree_utils and initializer in host_logon_session.