### PR TITLE
Avoid httpx 0.28.0 for unit tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ coverage>=5.5
 docutils<0.22.0
 filelock>=3.0.0
 flake8>=3.8.4
+httpx>=0.23.0, <0.28.0
 isort>=5.10.1
 jsonschema>=4.17.3
 markdown>=3.3.4


### PR DESCRIPTION
Respx (as of Dec 2024) in incompatible with httpx 0.28.0 because of change in encoding of URLs. While we wait for a new release of respx we need to say on on 0.27.0 for unit tests. This should have no impact on production use.