### PR TITLE
Fix logic issue with MSI auth

### DIFF
--- a/msticpy/auth/azure_auth_core.py
+++ b/msticpy/auth/azure_auth_core.py
@@ -177,7 +177,7 @@ def _build_msi_client(
 ) -> ManagedIdentityCredential:
     """Build a credential from Managed Identity."""
     msi_kwargs: dict[str, Any] = kwargs.copy()
-    client_id = client_id or os.environ.get(AzureCredEnvNames.AZURE_CLIENT_ID)
+    client_id = os.environ.get(AzureCredEnvNames.AZURE_CLIENT_ID, client_id)
 
     try:
         cred = ManagedIdentityCredential(client_id=client_id)


### PR DESCRIPTION
Fix an issue with the MSI authentication.

For a workflow with:
* authentication to the end resource with application secret stored in a keyvault
* authentication to the keyvault with a managed identity

For the first pass (to authenticate against the KV) the value "client_id" is not set and properly retrieved from the environment.
However, once the creds are retrieved from the KV, an msi connection is also attempted with the client_id from the keyvault.

This fix aims to prevent that issue, and is more consistent with what was [previously implemented](https://github.com/microsoft/msticpy/commit/4d715ad8fc6463139c713b016c62979f90379b3f#diff-6771b2174771c45ed1b09e0b2e0cc3df276f6c8668c27dfdda15403bd2148635L151):
```
    msi_kwargs = kwargs.copy()
     if AzureCredEnvNames.AZURE_CLIENT_ID in os.environ:
         msi_kwargs["client_id"] = os.environ[AzureCredEnvNames.AZURE_CLIENT_ID]
``` 