### PR TITLE
Fix scopes for SecurityGraph provider

### DIFF
--- a/msticpy/data/drivers/security_graph_driver.py
+++ b/msticpy/data/drivers/security_graph_driver.py
@@ -39,8 +39,8 @@ class SecurityGraphDriver(OData):
         """
         super().__init__(**kwargs)
         az_cloud_config = AzureCloudConfig(cloud=kwargs.pop("cloud", None))
-        self.scopes = [f"{self.api_root}.default"]
         self.api_root = az_cloud_config.endpoints.get("microsoftGraphResourceId")
+        self.scopes = [f"{self.api_root}.default"]
         self.req_body = {
             "client_id": None,
             "client_secret": None,  # nosec

--- a/msticpy/data/drivers/security_graph_driver.py
+++ b/msticpy/data/drivers/security_graph_driver.py
@@ -39,7 +39,7 @@ class SecurityGraphDriver(OData):
         """
         super().__init__(**kwargs)
         az_cloud_config = AzureCloudConfig(cloud=kwargs.pop("cloud", None))
-        self.scopes = ["User.Read"]
+        self.scopes = [f"{self.api_root}.default"]
         self.api_root = az_cloud_config.endpoints.get("microsoftGraphResourceId")
         self.req_body = {
             "client_id": None,


### PR DESCRIPTION
Hello,

When trying to use the `SecurityGraph` provider through an application, I am getting the following error:

```
auth_result (dict) = {"error":"invalid_scope","error_description":"AADSTS1002012: The provided value for scope User.Read is not valid. Client credential flows must have a scope value with /.default suffixed to the resource identifier (application ID URI). [...]
```

The `["User.Read"]` scopes in the driver is what is causing the issue.

When `scopes` is overridden to `["https://graph.microsoft.com/.default"]` with the code below, the authentication is successful:

```
security_graph_provider = QueryProvider("SecurityGraph")
query_provider = security_graph_provider._query_provider
query_provider.scopes = ["https://graph.microsoft.com/.default"]
security_graph_provider.connect()
```