### PR TITLE
Consolidate dependency updates and add Python 3.14 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: read-all
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       # Print out details about the run
       - name: Dump GitHub context

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ httpx>=0.28.0, <1.0.0
 ipython>=8.39.0; python_version <= '3.10'
 ipython>=9.13.0; python_version >= '3.11'
 jinja2>=3.1.6, <3.2.0
-numpy>=1.15.4
+numpy>=2.5.1
 pandas>=1.1.5
 pydantic>=1.8.0, <3.0.0
 python-dateutil>=2.9.0.post0

--- a/msticpy/_version.py
+++ b/msticpy/_version.py
@@ -1,3 +1,3 @@
 """Version file."""
 
-VERSION = "3.0.2"
+VERSION = "3.0.3"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.13.5
+aiohttp>=3.14.3
 async-cache>=1.1.1
 bandit>=1.9.4
 beautifulsoup4>=4.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.14.0  # (sec vuln) transitive dependency via geoip2
+aiohttp>=3.14.3  # (sec vuln) transitive dependency via geoip2
 attrs>=18.2.0
 azure-common>=1.1.18
 azure-core>=1.38.0
@@ -13,8 +13,8 @@ beautifulsoup4>=4.15.0
 bokeh>=3.0.0
 cryptography>=48.0.0
 deprecated>=1.2.4
-dnspython>=2.0.0, <3.0.0
-folium>=0.9.0
+dnspython>=2.8.0, <3.0.0
+folium>=0.20.0
 geoip2>=2.9.0
 h11>=0.16.0  # (sec vuln) transitive dependency via httpx
 html5lib
@@ -32,10 +32,12 @@ msal>=1.12.0
 msrest>=0.6.0
 nest_asyncio>=1.6.0
 networkx>=2.2
-numpy>=1.15.4  # pandas
+numpy>=2.2.6, <2.3.0; python_version == '3.10'
+numpy>=2.4.6, <2.5.0; python_version == '3.11'
+numpy>=2.5.1; python_version >= '3.12'
 packaging>=26.2
 pandas>=1.4.0, <3.0.0
-panel>=1.2.1
+panel>=1.9.3
 Pillow>=12.2.0  # (sec vuln) transitive dependency via bokeh
 pydantic>=1.8.0, <3.0.0
 pygments>=2.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
## Summary

Consolidates the dependency updates from #924, #925, #926, #927, and #928:

- folium 0.20.0
- aiohttp 3.14.3
- dnspython 2.8.0
- panel 1.9.3
- NumPy 2.x, with Python-compatible release lines
- package version 3.0.2 -> 3.0.3
- add Python 3.14 to package classifiers and CI

## NumPy compatibility

NumPy 2.5.1 requires Python 3.12+, which made #928 uninstallable on the supported Python 3.10 and 3.11 builds. There is no open NumPy Dependabot security alert for this repository and #928 is a routine version update, so this PR retains those supported Python versions and selects the newest compatible NumPy line:

- Python 3.10: NumPy 2.2.x
- Python 3.11: NumPy 2.4.x
- Python 3.12+: NumPy 2.5.1+

## Local validation

- Ruff
- mypy
- dependency resolution for each NumPy/Python compatibility tier
- full tests: 1454 passed, 68 skipped; 9 local-only failures require an unavailable MaxMind GeoIP database/configuration

Closes #924
Closes #925
Closes #926
Closes #927
Closes #928