### PR TITLE
Fix the User-Agent header name sent by mp_ua_header()

### DIFF
--- a/msticpy/common/utility/package.py
+++ b/msticpy/common/utility/package.py
@@ -191,7 +191,7 @@ _MSTICPY_USER_AGENT = _get_mp_ua()
 @export
 def mp_ua_header() -> dict[str, str]:
     """Return headers dict for MSTICPy User Agent."""
-    return {"UserAgent": _get_mp_ua()}
+    return {"User-Agent": _get_mp_ua()}
 
 
 @export

--- a/msticpy/data/drivers/azure_monitor_driver.py
+++ b/msticpy/data/drivers/azure_monitor_driver.py
@@ -43,7 +43,7 @@ from ...common.exceptions import (
 from ...common.provider_settings import get_protected_setting
 from ...common.settings import get_http_proxies, get_http_timeout
 from ...common.timespan import TimeSpan
-from ...common.utility import export, mp_ua_header
+from ...common.utility import MSTICPY_USER_AGENT, export, mp_ua_header
 from ...common.wsconfig import WorkspaceConfig
 from ..core.query_defns import DataEnvironment
 from .driver_base import DriverBase, DriverProps, QuerySource
@@ -117,7 +117,7 @@ class AzureMonitorDriver(DriverBase):
             {"list": self._format_list},
         )
         self._loaded = True
-        self._ua_policy = UserAgentPolicy(user_agent=mp_ua_header()["UserAgent"])
+        self._ua_policy = UserAgentPolicy(user_agent=MSTICPY_USER_AGENT)
         self._def_timeout = kwargs.get(
             "timeout", kwargs.get("server_timeout", self._DEFAULT_TIMEOUT)
         )


### PR DESCRIPTION
`mp_ua_header()` returns the key `UserAgent`, which is not the HTTP `User-Agent`
header. The result is that the MSTICPy identifier is sent under a header name
nothing reads, and httpx fills in the real `User-Agent` with its own default, so
requests are seen by upstream services as `python-httpx/<version>`.

## Reproducing

```python
>>> from msticpy.common.utility import mp_ua_header
>>> mp_ua_header()
{'UserAgent': 'MSTICPy3.0.2-Python3.12.7-linux'}
```

Pointing any `HttpTIProvider` at a local HTTP server and dumping the received
headers shows both, with only the wrong one carrying our identifier:

```
User-Agent: python-httpx/0.28.1
UserAgent:  MSTICPy3.0.2-Python3.12.7-linux
```

## Where it came from

The header was set correctly until #454. Before that change,
`http_provider.py` read:

```python
if "User-Agent" not in req_dict["headers"]:
    req_dict["headers"]["User-Agent"] = _MSTICPY_USER_AGENT
```

and it became:

```python
if "User-Agent" not in req_dict["headers"]:
    req_dict["headers"].update(mp_ua_header())
```

The guard still tests `User-Agent`, but the key written is now `UserAgent`, so
the guard never observes its own write. This means the intent of #319, to
identify MSTICPy in outbound HTTP requests, has not taken effect since then.

## The change

Two lines:

1. `common/utility/package.py` returns `{"User-Agent": ...}`.
2. `data/drivers/azure_monitor_driver.py` used `mp_ua_header()["UserAgent"]` to
   get the string for `UserAgentPolicy`. It now uses the already-exported
   `MSTICPY_USER_AGENT` constant, which is what it actually wants and is
   independent of the header name.

`mp_ua_header()` has 25 call sites across 14 modules, all of which pass it to
httpx as `headers=`, so they are all corrected by (1).

Providers that already declare their own `User-Agent` (`crowdsec`,
`virustotal`, `prismacloud_driver`) are unaffected: the guard in
`http_provider.py` continues to leave them alone, and that guard now works as
written.

## Verification

- `tests/context/test_tiproviders.py` and
  `tests/data/drivers/test_azure_monitor_driver.py` pass. Changing only (1)
  fails `test_ti_config_and_load` with `KeyError: 'UserAgent'`, which is what
  identified the `azure_monitor_driver` usage.
- Re-running the local-server check above shows a single
  `User-Agent: MSTICPy...` and no `UserAgent` header.

## Note

This changes what every MSTICPy deployment sends on outbound requests, from
`python-httpx/<version>` to the MSTICPy identifier. That is the intended
behaviour, but it is a visible change to upstream services rather than a no-op,
so it may be worth a release-note line.
